### PR TITLE
fix(manage-center sdk vm-service): 处理在没有监控或日志索引时，查看监控信息或者日志信息页面报错的问题

### DIFF
--- a/framework/management-center/backend/src/main/java/com/fit2cloud/service/impl/LogServiceImpl.java
+++ b/framework/management-center/backend/src/main/java/com/fit2cloud/service/impl/LogServiceImpl.java
@@ -49,6 +49,9 @@ public class LogServiceImpl implements ILogService {
     @Override
     public IPage<SystemLogVO> systemLogs(PageSystemLogRequest request) {
         Page<SystemLogVO> page = PageUtil.of(request, SystemLogVO.class, true);
+        if(!provide.existsIndex(CE_FILE_SYSTEM_LOGS)){
+            return page;
+        }
         return provide.searchByQuery(CE_FILE_SYSTEM_LOGS, getSearchQuery(request.getCurrentPage(), request.getPageSize(), JsonUtil.toJSONString(request), request.getOrder()), SystemLogVO.class, page);
     }
 
@@ -56,6 +59,9 @@ public class LogServiceImpl implements ILogService {
     @Override
     public IPage<OperatedLogVO> operatedLogs(PageOperatedLogRequest request) {
         Page<OperatedLogVO> page = PageUtil.of(request, OperatedLogVO.class, true);
+        if(!provide.existsIndex(CE_FILE_API_LOGS)){
+            return page;
+        }
         return provide.searchByQuery(CE_FILE_API_LOGS, getSearchQueryFroOperation(request.getCurrentPage(), request.getPageSize(), request, request.getOrder()), OperatedLogVO.class, page);
     }
 

--- a/framework/management-center/backend/src/main/java/com/fit2cloud/service/impl/LogServiceImpl.java
+++ b/framework/management-center/backend/src/main/java/com/fit2cloud/service/impl/LogServiceImpl.java
@@ -49,7 +49,7 @@ public class LogServiceImpl implements ILogService {
     @Override
     public IPage<SystemLogVO> systemLogs(PageSystemLogRequest request) {
         Page<SystemLogVO> page = PageUtil.of(request, SystemLogVO.class, true);
-        if(!provide.existsIndex(CE_FILE_SYSTEM_LOGS)){
+        if (!provide.existsIndex(CE_FILE_SYSTEM_LOGS)) {
             return page;
         }
         return provide.searchByQuery(CE_FILE_SYSTEM_LOGS, getSearchQuery(request.getCurrentPage(), request.getPageSize(), JsonUtil.toJSONString(request), request.getOrder()), SystemLogVO.class, page);
@@ -59,7 +59,7 @@ public class LogServiceImpl implements ILogService {
     @Override
     public IPage<OperatedLogVO> operatedLogs(PageOperatedLogRequest request) {
         Page<OperatedLogVO> page = PageUtil.of(request, OperatedLogVO.class, true);
-        if(!provide.existsIndex(CE_FILE_API_LOGS)){
+        if (!provide.existsIndex(CE_FILE_API_LOGS)) {
             return page;
         }
         return provide.searchByQuery(CE_FILE_API_LOGS, getSearchQueryFroOperation(request.getCurrentPage(), request.getPageSize(), request, request.getOrder()), OperatedLogVO.class, page);

--- a/framework/sdk/backend/src/main/java/com/fit2cloud/service/PerfMonitorService.java
+++ b/framework/sdk/backend/src/main/java/com/fit2cloud/service/PerfMonitorService.java
@@ -34,7 +34,7 @@ public class PerfMonitorService {
 
     public Map<String, List<PerfMonitorEchartsDTO>> getPerfMonitorData(PerfMonitorRequest request) {
         Map<String, List<PerfMonitorEchartsDTO>> resultMap = new HashMap<>();
-        if(!elasticsearchProvide.existsIndex(IndexConstants.CE_PERF_METRIC_MONITOR_DATA.getCode())){
+        if (!elasticsearchProvide.existsIndex(IndexConstants.CE_PERF_METRIC_MONITOR_DATA.getCode())) {
             return resultMap;
         }
         List<PerfMetricMonitorData> esList = elasticsearchProvide.searchByQuery(IndexConstants.CE_PERF_METRIC_MONITOR_DATA.getCode(), getSearchQuery(request), PerfMetricMonitorData.class);

--- a/framework/sdk/backend/src/main/java/com/fit2cloud/service/PerfMonitorService.java
+++ b/framework/sdk/backend/src/main/java/com/fit2cloud/service/PerfMonitorService.java
@@ -34,6 +34,9 @@ public class PerfMonitorService {
 
     public Map<String, List<PerfMonitorEchartsDTO>> getPerfMonitorData(PerfMonitorRequest request) {
         Map<String, List<PerfMonitorEchartsDTO>> resultMap = new HashMap<>();
+        if(!elasticsearchProvide.existsIndex(IndexConstants.CE_PERF_METRIC_MONITOR_DATA.getCode())){
+            return resultMap;
+        }
         List<PerfMetricMonitorData> esList = elasticsearchProvide.searchByQuery(IndexConstants.CE_PERF_METRIC_MONITOR_DATA.getCode(), getSearchQuery(request), PerfMetricMonitorData.class);
         if (esList.size() > 0) {
             Long startTime = request.getStartTime();

--- a/services/operation-analysis/backend/src/main/java/com/fit2cloud/service/impl/BaseResourceAnalysisServiceImpl.java
+++ b/services/operation-analysis/backend/src/main/java/com/fit2cloud/service/impl/BaseResourceAnalysisServiceImpl.java
@@ -316,7 +316,7 @@ public class BaseResourceAnalysisServiceImpl implements IBaseResourceAnalysisSer
     @Override
     public List<ChartData> getResourceUsedTrendData(ResourceUsedTrendRequest request) {
         List<ChartData> result = new ArrayList<>();
-        if(!elasticsearchProvide.existsIndex(IndexConstants.CE_PERF_METRIC_MONITOR_DATA.getCode())){
+        if (!elasticsearchProvide.existsIndex(IndexConstants.CE_PERF_METRIC_MONITOR_DATA.getCode())) {
             return result;
         }
         CalendarInterval intervalUnit = OperationUtils.getCalendarIntervalUnit(request.getStartTime(), request.getEndTime());

--- a/services/operation-analysis/backend/src/main/java/com/fit2cloud/service/impl/BaseResourceAnalysisServiceImpl.java
+++ b/services/operation-analysis/backend/src/main/java/com/fit2cloud/service/impl/BaseResourceAnalysisServiceImpl.java
@@ -316,6 +316,9 @@ public class BaseResourceAnalysisServiceImpl implements IBaseResourceAnalysisSer
     @Override
     public List<ChartData> getResourceUsedTrendData(ResourceUsedTrendRequest request) {
         List<ChartData> result = new ArrayList<>();
+        if(!elasticsearchProvide.existsIndex(IndexConstants.CE_PERF_METRIC_MONITOR_DATA.getCode())){
+            return result;
+        }
         CalendarInterval intervalUnit = OperationUtils.getCalendarIntervalUnit(request.getStartTime(), request.getEndTime());
         try {
             request.setIntervalPosition(intervalUnit);

--- a/services/operation-analysis/backend/src/main/java/com/fit2cloud/service/impl/ServerAnalysisServiceImpl.java
+++ b/services/operation-analysis/backend/src/main/java/com/fit2cloud/service/impl/ServerAnalysisServiceImpl.java
@@ -318,32 +318,34 @@ public class ServerAnalysisServiceImpl implements IServerAnalysisService {
     public void getVmPerfMetric(List<AnalysisServerDTO> list) {
         List<String> instanceUuids = list.stream().map(AnalysisServerDTO::getInstanceUuid).filter(StringUtils::isNotEmpty).toList();
         try {
-            Query query = getVmPerfMetricQuery(instanceUuids);
-            SearchHits<Object> response = elasticsearchTemplate.search(query, Object.class, IndexCoordinates.of(IndexConstants.CE_PERF_METRIC_MONITOR_DATA.getCode()));
-            ElasticsearchAggregations aggregations = (ElasticsearchAggregations) response.getAggregations();
-            assert aggregations != null;
-            List<StringTermsBucket> lastData = aggregations.aggregations().get(0).aggregation().getAggregate().sterms().buckets().array();
-            List<PerfMetricMonitorData> metricMonitorDataList = new ArrayList<>();
-            lastData.forEach(data -> data.aggregations().get("lastData").sterms().buckets().array().forEach(m -> {
-                PerfMetricMonitorData vo = JsonUtil.parseObject(Objects.requireNonNull(m.aggregations().get("top1").topHits().hits().hits().get(0).source()).toString(), PerfMetricMonitorData.class);
-                metricMonitorDataList.add(vo);
-            }));
-            list.forEach(v -> metricMonitorDataList.stream().filter(d -> StringUtils.equalsIgnoreCase(v.getInstanceUuid(), d.getInstanceId())
-                    && StringUtils.equalsIgnoreCase(v.getAccountId(), d.getCloudAccountId())).forEach(m -> {
-                if (StringUtils.equalsIgnoreCase(ResourcePerfMetricEnum.CPU_USED_UTILIZATION.name(), m.getMetricName())) {
-                    v.setCpuAverage(m.getAverage().setScale(3, RoundingMode.HALF_UP));
-                    v.setCpuMaximum(m.getMaximum().setScale(3, RoundingMode.HALF_UP));
-                    v.setCpuMinimum(m.getMinimum().setScale(3, RoundingMode.HALF_UP));
-                }
-                if (StringUtils.equalsIgnoreCase(ResourcePerfMetricEnum.MEMORY_USED_UTILIZATION.name(), m.getMetricName())) {
-                    v.setMemoryAverage(m.getAverage().setScale(3, RoundingMode.HALF_UP));
-                    v.setMemoryMaximum(m.getMaximum().setScale(3, RoundingMode.HALF_UP));
-                    v.setMemoryMinimum(m.getMinimum().setScale(3, RoundingMode.HALF_UP));
-                }
-                if (StringUtils.equalsIgnoreCase(ResourcePerfMetricEnum.DISK_USED_UTILIZATION.name(), m.getMetricName())) {
-                    v.setDiskAverage(m.getAverage().setScale(3, RoundingMode.HALF_UP));
-                }
-            }));
+            if(elasticsearchTemplate.indexOps(IndexCoordinates.of(IndexConstants.CE_PERF_METRIC_MONITOR_DATA.getCode())).exists()){
+                Query query = getVmPerfMetricQuery(instanceUuids);
+                SearchHits<Object> response = elasticsearchTemplate.search(query, Object.class, IndexCoordinates.of(IndexConstants.CE_PERF_METRIC_MONITOR_DATA.getCode()));
+                ElasticsearchAggregations aggregations = (ElasticsearchAggregations) response.getAggregations();
+                assert aggregations != null;
+                List<StringTermsBucket> lastData = aggregations.aggregations().get(0).aggregation().getAggregate().sterms().buckets().array();
+                List<PerfMetricMonitorData> metricMonitorDataList = new ArrayList<>();
+                lastData.forEach(data -> data.aggregations().get("lastData").sterms().buckets().array().forEach(m -> {
+                    PerfMetricMonitorData vo = JsonUtil.parseObject(Objects.requireNonNull(m.aggregations().get("top1").topHits().hits().hits().get(0).source()).toString(), PerfMetricMonitorData.class);
+                    metricMonitorDataList.add(vo);
+                }));
+                list.forEach(v -> metricMonitorDataList.stream().filter(d -> StringUtils.equalsIgnoreCase(v.getInstanceUuid(), d.getInstanceId())
+                        && StringUtils.equalsIgnoreCase(v.getAccountId(), d.getCloudAccountId())).forEach(m -> {
+                    if (StringUtils.equalsIgnoreCase(ResourcePerfMetricEnum.CPU_USED_UTILIZATION.name(), m.getMetricName())) {
+                        v.setCpuAverage(m.getAverage().setScale(3, RoundingMode.HALF_UP));
+                        v.setCpuMaximum(m.getMaximum().setScale(3, RoundingMode.HALF_UP));
+                        v.setCpuMinimum(m.getMinimum().setScale(3, RoundingMode.HALF_UP));
+                    }
+                    if (StringUtils.equalsIgnoreCase(ResourcePerfMetricEnum.MEMORY_USED_UTILIZATION.name(), m.getMetricName())) {
+                        v.setMemoryAverage(m.getAverage().setScale(3, RoundingMode.HALF_UP));
+                        v.setMemoryMaximum(m.getMaximum().setScale(3, RoundingMode.HALF_UP));
+                        v.setMemoryMinimum(m.getMinimum().setScale(3, RoundingMode.HALF_UP));
+                    }
+                    if (StringUtils.equalsIgnoreCase(ResourcePerfMetricEnum.DISK_USED_UTILIZATION.name(), m.getMetricName())) {
+                        v.setDiskAverage(m.getAverage().setScale(3, RoundingMode.HALF_UP));
+                    }
+                }));
+            }
         } catch (Exception e) {
             e.printStackTrace();
         }
@@ -385,6 +387,9 @@ public class ServerAnalysisServiceImpl implements IServerAnalysisService {
     @Override
     public List<ChartData> getResourceTrendData(ResourceAnalysisRequest request) {
         List<ChartData> result = new ArrayList<>();
+        if(!elasticsearchTemplate.indexOps(IndexCoordinates.of(IndexConstants.CE_PERF_METRIC_MONITOR_DATA.getCode())).exists()){
+            return result;
+        }
         if (CollectionUtils.isEmpty(request.getAccountIds())) {
             request.setAccountIds(currentUserResourceService.currentUserCloudAccountList().stream().map(CloudAccount::getId).toList());
         }

--- a/services/operation-analysis/backend/src/main/java/com/fit2cloud/service/impl/ServerAnalysisServiceImpl.java
+++ b/services/operation-analysis/backend/src/main/java/com/fit2cloud/service/impl/ServerAnalysisServiceImpl.java
@@ -318,7 +318,7 @@ public class ServerAnalysisServiceImpl implements IServerAnalysisService {
     public void getVmPerfMetric(List<AnalysisServerDTO> list) {
         List<String> instanceUuids = list.stream().map(AnalysisServerDTO::getInstanceUuid).filter(StringUtils::isNotEmpty).toList();
         try {
-            if(elasticsearchTemplate.indexOps(IndexCoordinates.of(IndexConstants.CE_PERF_METRIC_MONITOR_DATA.getCode())).exists()){
+            if (elasticsearchTemplate.indexOps(IndexCoordinates.of(IndexConstants.CE_PERF_METRIC_MONITOR_DATA.getCode())).exists()) {
                 Query query = getVmPerfMetricQuery(instanceUuids);
                 SearchHits<Object> response = elasticsearchTemplate.search(query, Object.class, IndexCoordinates.of(IndexConstants.CE_PERF_METRIC_MONITOR_DATA.getCode()));
                 ElasticsearchAggregations aggregations = (ElasticsearchAggregations) response.getAggregations();
@@ -387,7 +387,7 @@ public class ServerAnalysisServiceImpl implements IServerAnalysisService {
     @Override
     public List<ChartData> getResourceTrendData(ResourceAnalysisRequest request) {
         List<ChartData> result = new ArrayList<>();
-        if(!elasticsearchTemplate.indexOps(IndexCoordinates.of(IndexConstants.CE_PERF_METRIC_MONITOR_DATA.getCode())).exists()){
+        if (!elasticsearchTemplate.indexOps(IndexCoordinates.of(IndexConstants.CE_PERF_METRIC_MONITOR_DATA.getCode())).exists()) {
             return result;
         }
         if (CollectionUtils.isEmpty(request.getAccountIds())) {


### PR DESCRIPTION
在ES上如果没有成功创建创建监控或者日志的相关索引时，在云平台上查看监控信息或者日志，页面上会报错