### PR TITLE
fix(vm-service): 创建中的机器，遇到同步任务，会在列表中多一条记录

### DIFF
--- a/services/vm-service/backend/src/main/java/com/fit2cloud/service/impl/VmCloudDiskServiceImpl.java
+++ b/services/vm-service/backend/src/main/java/com/fit2cloud/service/impl/VmCloudDiskServiceImpl.java
@@ -586,7 +586,7 @@ public class VmCloudDiskServiceImpl extends ServiceImpl<BaseVmCloudDiskMapper, V
                 vmCloudDisk.setCreateTime(LocalDateTime.now());
             }
             String diskId = UUID.randomUUID().toString().replace("-", "");
-            QueryWrapper<VmCloudDisk> queryWrapper = new QueryWrapper();
+            QueryWrapper<VmCloudDisk> queryWrapper = new QueryWrapper<>();
             queryWrapper.lambda()
                     .eq(VmCloudDisk::getAccountId, accountId)
                     .eq(VmCloudDisk::getRegion, f2cDisk.getRegion())


### PR DESCRIPTION
fix(vm-service): 创建中的机器，遇到同步任务，会在列表中多一条记录  现在修改后，等新建云主机任务完成，列表查询只会查到一条与任务关联的记录 