### PR TITLE
[运营分析]明细列表添加字段，以及显示优化

### DIFF
--- a/services/operation-analysis/backend/src/main/java/com/fit2cloud/service/impl/BaseResourceAnalysisServiceImpl.java
+++ b/services/operation-analysis/backend/src/main/java/com/fit2cloud/service/impl/BaseResourceAnalysisServiceImpl.java
@@ -122,7 +122,7 @@ public class BaseResourceAnalysisServiceImpl implements IBaseResourceAnalysisSer
         IPage<AnalysisDatastoreDTO> result = baseVmCloudDatastoreMapper.selectJoinPage(page, AnalysisDatastoreDTO.class, wrapper);
         //计算
         result.getRecords().forEach(v -> {
-            v.setAllocated(String.valueOf(v.getCapacity() - v.getFreeSpace()));
+            v.setAllocated(String.valueOf(v.getAllocatedSpace()));
             BigDecimal useRate = new BigDecimal(v.getCapacity()).subtract(new BigDecimal(v.getFreeSpace())).multiply(new BigDecimal(100)).divide(new BigDecimal(v.getCapacity()), 2, RoundingMode.UP);
             v.setUseRate(String.valueOf(useRate));
             BigDecimal freeRate = new BigDecimal(v.getFreeSpace()).multiply(new BigDecimal(100)).divide(new BigDecimal(v.getCapacity()), 2, RoundingMode.UP);
@@ -235,8 +235,9 @@ public class BaseResourceAnalysisServiceImpl implements IBaseResourceAnalysisSer
         List<VmCloudHost> hosts = getVmHost(request);
         if (CollectionUtils.isNotEmpty(hosts)) {
             hosts = hosts.stream().filter(v -> !CollectionUtils.isNotEmpty(request.getHostIds()) || request.getHostIds().contains(v.getId())).toList();
-            BigDecimal cpuTotal = new BigDecimal(hosts.stream().filter(v -> Objects.nonNull(v.getCpuTotal())).mapToLong(VmCloudHost::getCpuTotal).sum());
-            BigDecimal cpuAllocated = new BigDecimal(hosts.stream().filter(v -> Objects.nonNull(v.getCpuAllocated())).mapToLong(VmCloudHost::getCpuAllocated).sum());
+            // 取core
+            BigDecimal cpuTotal = new BigDecimal(hosts.stream().filter(v -> Objects.nonNull(v.getNumCpuCores())).mapToLong(VmCloudHost::getNumCpuCores).sum());
+            BigDecimal cpuAllocated = new BigDecimal(hosts.stream().filter(v -> Objects.nonNull(v.getVmCpuCores())).mapToLong(VmCloudHost::getVmCpuCores).sum());
             BigDecimal cpuAllocatedRate = cpuAllocated.divide(cpuTotal, 2, RoundingMode.HALF_UP).multiply(new BigDecimal(100));
             result.put(SpecialAttributesConstants.ResourceField.CPU, ResourceAllocatedInfo.builder()
                     .total(cpuTotal)
@@ -258,7 +259,7 @@ public class BaseResourceAnalysisServiceImpl implements IBaseResourceAnalysisSer
             datastoreList = datastoreList.stream().filter(v -> !CollectionUtils.isNotEmpty(request.getDatastoreIds()) || request.getDatastoreIds().contains(v.getId())).toList();
             BigDecimal capacity = new BigDecimal(datastoreList.stream().filter(v -> Objects.nonNull(v.getCapacity())).mapToLong(VmCloudDatastore::getCapacity).sum());
             BigDecimal allocatedSpace = new BigDecimal(datastoreList.stream().filter(v -> Objects.nonNull(v.getAllocatedSpace())).mapToLong(VmCloudDatastore::getAllocatedSpace).sum());
-            BigDecimal memoryAllocatedRate = capacity.subtract(allocatedSpace).divide(capacity, 2, RoundingMode.HALF_UP).multiply(new BigDecimal(100));
+            BigDecimal memoryAllocatedRate = allocatedSpace.divide(capacity, 2, RoundingMode.HALF_UP).multiply(new BigDecimal(100));
             result.put(SpecialAttributesConstants.ResourceField.DATASTORE, ResourceAllocatedInfo.builder()
                     .total(capacity)
                     .allocated(allocatedSpace)
@@ -477,6 +478,7 @@ public class BaseResourceAnalysisServiceImpl implements IBaseResourceAnalysisSer
             result.put("memory", ResourceAllocatedInfo.builder()
                     .total(memoryTotal.divide(new BigDecimal(1024), RoundingMode.HALF_UP))
                     .allocated(memoryUsedRate.divide(new BigDecimal(1024), RoundingMode.HALF_UP))
+                    .used(memoryUsed)
                     .usedRate(memoryUsedRate.compareTo(new BigDecimal(100)) > 0 ? new BigDecimal(100) : memoryUsedRate)
                     .build());
 

--- a/services/operation-analysis/frontend/src/views/base_resource_analysis/hostList.vue
+++ b/services/operation-analysis/frontend/src/views/base_resource_analysis/hostList.vue
@@ -135,6 +135,10 @@ onMounted(() => {
       ></el-table-column>
       <el-table-column prop="vmCpuCores" label="CPU已分配(核)" min-width="150">
       </el-table-column>
+      <el-table-column prop="cpuTotal" label="CPU总量(MHz)" min-width="150">
+      </el-table-column>
+      <el-table-column prop="cpuUsed" label="CPU已使用(MHz)" min-width="150">
+      </el-table-column>
       <el-table-column prop="memoryTotal" label="内存总量(GB)" min-width="150">
         <template #default="scope">
           {{ (scope.row.memoryTotal / 1024).toFixed(2) }}
@@ -147,6 +151,11 @@ onMounted(() => {
       >
         <template #default="scope">
           {{ (scope.row.memoryAllocated / 1024).toFixed(2) }}
+        </template>
+      </el-table-column>
+      <el-table-column prop="cpuUsed" label="内存已使用(GB)" min-width="150">
+        <template #default="scope">
+          {{ (scope.row.cpuUsed / 1024).toFixed(2) }}
         </template>
       </el-table-column>
       <el-table-column

--- a/services/operation-analysis/frontend/src/views/base_resource_analysis/hostList.vue
+++ b/services/operation-analysis/frontend/src/views/base_resource_analysis/hostList.vue
@@ -10,6 +10,7 @@ import {
   TableSearch,
 } from "@commons/components/ce-table/type";
 import { useI18n } from "vue-i18n";
+
 const { t } = useI18n();
 const table = ref<any>(null);
 const columns = ref([]);
@@ -83,7 +84,7 @@ onMounted(() => {
       height="100%"
       ref="table"
     >
-      <template #toolbar> </template>
+      <template #toolbar></template>
       <el-table-column type="selection" />
       <el-table-column
         :show-overflow-tooltip="true"
@@ -122,24 +123,74 @@ onMounted(() => {
         label="数据中心"
         :show="false"
       ></el-table-column>
-      <el-table-column prop="zone" label="集群" :show="false"></el-table-column>
+      <el-table-column prop="zone" label="集群" :show="false">
+      </el-table-column>
       <el-table-column
         prop="hostIp"
         label="IP地址"
         :show="false"
       ></el-table-column>
       <el-table-column
+        align="right"
         prop="numCpuCores"
         label="CPU总量(核)"
         width="120"
       ></el-table-column>
-      <el-table-column prop="vmCpuCores" label="CPU已分配(核)" min-width="150">
+      <el-table-column
+        align="right"
+        prop="vmCpuCores"
+        label="CPU已分配(核)"
+        min-width="150"
+      >
       </el-table-column>
-      <el-table-column prop="cpuTotal" label="CPU总量(MHz)" min-width="150">
+      <el-table-column
+        :show="false"
+        align="right"
+        prop="memoryTotal"
+        label="CPU分配率"
+        min-width="150"
+      >
+        <template #default="scope">
+          {{ (scope.row.vmCpuCores / scope.row.numCpuCores).toFixed(2) * 100 }}%
+        </template>
       </el-table-column>
-      <el-table-column prop="cpuUsed" label="CPU已使用(MHz)" min-width="150">
+      <el-table-column
+        align="right"
+        prop="cpuTotal"
+        label="CPU总量(MHz)"
+        min-width="150"
+      >
       </el-table-column>
-      <el-table-column prop="memoryTotal" label="内存总量(GB)" min-width="150">
+      <el-table-column
+        align="right"
+        prop="cpuUsed"
+        label="CPU已使用(MHz)"
+        min-width="150"
+      >
+        <template #default="scope">
+          {{ scope.row.cpuUsed ? scope.row.cpuUsed : "-" }}
+        </template>
+      </el-table-column>
+      <el-table-column
+        :show="false"
+        align="right"
+        label="CPU使用率"
+        min-width="150"
+      >
+        <template #default="scope">
+          {{
+            scope.row.cpuUsed
+              ? (scope.row.cpuUsed / scope.row.cpuTotal).toFixed(2) * 100 + "%"
+              : "-"
+          }}
+        </template>
+      </el-table-column>
+      <el-table-column
+        align="right"
+        prop="memoryTotal"
+        label="内存总量(GB)"
+        min-width="150"
+      >
         <template #default="scope">
           {{ (scope.row.memoryTotal / 1024).toFixed(2) }}
         </template>
@@ -148,22 +199,64 @@ onMounted(() => {
         prop="memoryAllocated"
         label="内存已分配(GB)"
         min-width="150"
+        align="right"
       >
         <template #default="scope">
           {{ (scope.row.memoryAllocated / 1024).toFixed(2) }}
         </template>
       </el-table-column>
-      <el-table-column prop="cpuUsed" label="内存已使用(GB)" min-width="150">
+      <el-table-column
+        :show="false"
+        align="right"
+        prop="memoryTotal"
+        label="内存分配率"
+        min-width="150"
+      >
         <template #default="scope">
-          {{ (scope.row.cpuUsed / 1024).toFixed(2) }}
+          {{
+            (scope.row.memoryAllocated / scope.row.memoryTotal).toFixed(2) *
+            100
+          }}%
         </template>
       </el-table-column>
       <el-table-column
+        align="right"
+        prop="memoryUsed"
+        label="内存已使用(GB)"
+        min-width="150"
+      >
+        <template #default="scope">
+          {{
+            scope.row.memoryUsed
+              ? (scope.row.memoryUsed / 1024).toFixed(2)
+              : "-"
+          }}
+        </template>
+      </el-table-column>
+      <el-table-column
+        :show="false"
+        align="right"
+        label="内存使用率"
+        min-width="150"
+      >
+        <template #default="scope">
+          {{
+            scope.row.memoryUsed
+              ? (scope.row.memoryUsed / scope.row.memoryTotal).toFixed(2) *
+                  100 +
+                "%"
+              : "-"
+          }}
+        </template>
+      </el-table-column>
+      <el-table-column
+        align="right"
         prop="vmTotal"
         label="云主机总数"
         min-width="150"
       ></el-table-column>
       <el-table-column
+        align="right"
         prop="vmRunning"
         label="运行中云主机"
         min-width="150"

--- a/services/operation-analysis/frontend/src/views/base_resource_analysis/item/BaseResourceSpread.vue
+++ b/services/operation-analysis/frontend/src/views/base_resource_analysis/item/BaseResourceSpread.vue
@@ -16,10 +16,10 @@
         <div class="echarts">
           <div class="echarts-content">
             <v-chart
-                class="chart"
-                :option="option"
-                v-loading="loading"
-                autoresize
+              class="chart"
+              :option="option"
+              v-loading="loading"
+              autoresize
             />
           </div>
         </div>
@@ -48,35 +48,35 @@ const loading = ref<boolean>(false);
 const apiData = ref<any>();
 const setParams = () => {
   props.cloudAccountId
-      ? _.set(
-          params,
-          "accountIds",
-          props.cloudAccountId === "all" ? [] : [props.cloudAccountId]
+    ? _.set(
+        params,
+        "accountIds",
+        props.cloudAccountId === "all" ? [] : [props.cloudAccountId]
       )
-      : "";
+    : "";
   props.clusterId
-      ? _.set(
-          params,
-          "clusterIds",
-          props.clusterId === "all" ? [] : [props.clusterId]
+    ? _.set(
+        params,
+        "clusterIds",
+        props.clusterId === "all" ? [] : [props.clusterId]
       )
-      : "";
+    : "";
   props.datastoreId
-      ? _.set(
-          params,
-          "datastoreIds",
-          props.datastoreId === "all" ? [] : [props.datastoreId]
+    ? _.set(
+        params,
+        "datastoreIds",
+        props.datastoreId === "all" ? [] : [props.datastoreId]
       )
-      : "";
+    : "";
   props.hostId
-      ? _.set(params, "hostIds", props.hostId === "all" ? [] : [props.hostId])
-      : "";
+    ? _.set(params, "hostIds", props.hostId === "all" ? [] : [props.hostId])
+    : "";
 };
 //获取数宿主机按云账号分布
 const getSpreadInfo = () => {
   setParams();
   ResourceSpreadViewApi.getSpreadInfo(params, loading).then(
-      (res) => (apiData.value = res.data)
+    (res) => (apiData.value = res.data)
   );
 };
 interface EchartsValue {
@@ -93,12 +93,12 @@ const data = computed<Array<EchartsValue>>(() => {
 });
 const option = computed<ECBasicOption>(() => {
   const selected = data.value
-      .map((b) => {
-        return { [b.name]: true };
-      })
-      .reduce((pre, next) => {
-        return { ...pre, ...next };
-      }, {});
+    .map((b) => {
+      return { [b.name]: true };
+    })
+    .reduce((pre, next) => {
+      return { ...pre, ...next };
+    }, {});
   if (data.value.length === 0) {
     return {
       title: {
@@ -166,9 +166,9 @@ const option = computed<ECBasicOption>(() => {
         const dataItem = data.value.find((b) => b.name === name);
 
         return `{oneone|${
-            (dataItem?.name as string).length < 8
-                ? dataItem?.name
-                : dataItem?.name.substring(0, 7) + "..."
+          (dataItem?.name as string).length < 8
+            ? dataItem?.name
+            : dataItem?.name.substring(0, 7) + "..."
         }}  {twotwo|${dataItem?.value}}`;
       },
     },
@@ -194,11 +194,11 @@ const option = computed<ECBasicOption>(() => {
           color: "rgba(100, 106, 115, 1)",
           formatter: () => {
             const sum = data.value
-                .filter((d) => (selected as SimpleMap<boolean>)[d.name])
-                .map((a) => a.value)
-                .reduce((p, n) => p + n, 0);
+              .filter((d) => (selected as SimpleMap<boolean>)[d.name])
+              .map((a) => a.value)
+              .reduce((p, n) => p + n, 0);
             return `{title|总数（${
-                spreadType.value === "host" ? "台" : "块"
+              spreadType.value === "host" ? "台" : "块"
             }）}\r\n{value|${sum}}`;
           },
           rich: {
@@ -232,47 +232,47 @@ const option = computed<ECBasicOption>(() => {
         },
         data: data.value,
         color:
-            apiData.value?.[spreadType.value].length === 0
-                ? ["rgba(187, 191, 196, 1)", "rgba(187, 191, 196, 1)"]
-                : interpolationColor(
-                    [
-                      "rgb(79, 131, 253, 1)",
-                      "rgb(150, 189, 255, 1)",
-                      "rgb(250, 211, 85, 1)",
-                      "rgb(255, 230, 104, 1)",
-                      "rgb(22, 225, 198, 1)",
-                      "rgb(76, 253, 224, 1)",
-                      "rgb(81, 206, 251, 1)",
-                      "rgb(118, 240, 255, 1)",
-                      "rgb(148, 90, 246, 1)",
-                      "rgb(220, 155, 255, 1)",
-                      "rgb(255, 165, 61, 1)",
-                      "rgb(255, 199, 94, 1)",
-                      "rgb(241, 75, 169, 1)",
-                      "rgb(255, 137, 227, 1)",
-                      "rgb(247, 105, 101, 1)",
-                      "rgb(255, 158, 149, 1)",
-                      "rgb(219, 102, 219, 1)",
-                      "rgb(254, 157, 254, 1)",
-                      "rgb(195, 221, 65, 1)",
-                      "rgb(217, 244, 87, 1)",
-                      "rgb(97, 106, 229, 1)",
-                      "rgb(172, 173, 255, 1)",
-                      "rgb(98, 210, 85, 1)",
-                      "rgb(134, 245, 120, 1)",
-                    ],
-                    data.value.length
-                ),
+          apiData.value?.[spreadType.value].length === 0
+            ? ["rgba(187, 191, 196, 1)", "rgba(187, 191, 196, 1)"]
+            : interpolationColor(
+                [
+                  "rgb(79, 131, 253, 1)",
+                  "rgb(150, 189, 255, 1)",
+                  "rgb(250, 211, 85, 1)",
+                  "rgb(255, 230, 104, 1)",
+                  "rgb(22, 225, 198, 1)",
+                  "rgb(76, 253, 224, 1)",
+                  "rgb(81, 206, 251, 1)",
+                  "rgb(118, 240, 255, 1)",
+                  "rgb(148, 90, 246, 1)",
+                  "rgb(220, 155, 255, 1)",
+                  "rgb(255, 165, 61, 1)",
+                  "rgb(255, 199, 94, 1)",
+                  "rgb(241, 75, 169, 1)",
+                  "rgb(255, 137, 227, 1)",
+                  "rgb(247, 105, 101, 1)",
+                  "rgb(255, 158, 149, 1)",
+                  "rgb(219, 102, 219, 1)",
+                  "rgb(254, 157, 254, 1)",
+                  "rgb(195, 221, 65, 1)",
+                  "rgb(217, 244, 87, 1)",
+                  "rgb(97, 106, 229, 1)",
+                  "rgb(172, 173, 255, 1)",
+                  "rgb(98, 210, 85, 1)",
+                  "rgb(134, 245, 120, 1)",
+                ],
+                data.value.length
+              ),
       },
     ],
   };
 });
 watch(
-    props,
-    () => {
-      getSpreadInfo();
-    },
-    { immediate: true }
+  props,
+  () => {
+    getSpreadInfo();
+  },
+  { immediate: true }
 );
 </script>
 <style scoped lang="scss">

--- a/services/operation-analysis/frontend/src/views/base_resource_analysis/item/BaseResourceUseRateTrend.vue
+++ b/services/operation-analysis/frontend/src/views/base_resource_analysis/item/BaseResourceUseRateTrend.vue
@@ -7,33 +7,33 @@
       <el-col :span="16" style="text-align: right">
         <div class="search-box">
           <el-date-picker
-              style="width: 200px; height: 32px; margin-right: 16px"
-              v-model="trendTime"
-              type="daterange"
-              v-if="showTrendTime"
-              unlink-panels
-              range-separator="至"
-              start-placeholder="开始时间"
-              end-placeholder="结束时间"
-              :shortcuts="shortcuts"
-              size="small"
-              @change="changeTimestamp"
-              @input="changeTimestamp"
+            style="width: 200px; height: 32px; margin-right: 16px"
+            v-model="trendTime"
+            type="daterange"
+            v-if="showTrendTime"
+            unlink-panels
+            range-separator="至"
+            start-placeholder="开始时间"
+            end-placeholder="结束时间"
+            :shortcuts="shortcuts"
+            size="small"
+            @change="changeTimestamp"
+            @input="changeTimestamp"
           />
           <el-radio-group
-              style="min-width: 300px"
-              class="custom-radio-group"
-              v-model="basicResourceType"
-              :on-change="getResourceTrendData()"
+            style="min-width: 300px"
+            class="custom-radio-group"
+            v-model="basicResourceType"
+            :on-change="getResourceTrendData()"
           >
             <el-radio-button label="CPU_USED_UTILIZATION"
-            >CPU使用率</el-radio-button
+              >CPU使用率</el-radio-button
             >
             <el-radio-button label="MEMORY_USED_UTILIZATION"
-            >内存使用率</el-radio-button
+              >内存使用率</el-radio-button
             >
             <el-radio-button label="DATASTORE_USED_UTILIZATION"
-            >存储器使用率</el-radio-button
+              >存储器使用率</el-radio-button
             >
           </el-radio-group>
         </div>
@@ -44,10 +44,10 @@
         <div class="echarts">
           <div class="echarts-content">
             <v-chart
-                class="chart"
-                :option="options"
-                v-loading="loading"
-                autoresize
+              class="chart"
+              :option="options"
+              v-loading="loading"
+              autoresize
             />
           </div>
         </div>
@@ -84,29 +84,29 @@ const apiData = ref<any>();
 
 const setParams = () => {
   props.cloudAccountId
-      ? _.set(
-          params,
-          "accountIds",
-          props.cloudAccountId === "all" ? [] : [props.cloudAccountId]
+    ? _.set(
+        params,
+        "accountIds",
+        props.cloudAccountId === "all" ? [] : [props.cloudAccountId]
       )
-      : "";
+    : "";
   props.clusterId
-      ? _.set(
-          params,
-          "clusterIds",
-          props.clusterId === "all" ? [] : [props.clusterId]
+    ? _.set(
+        params,
+        "clusterIds",
+        props.clusterId === "all" ? [] : [props.clusterId]
       )
-      : "";
+    : "";
   props.datastoreId
-      ? _.set(
-          params,
-          "datastoreIds",
-          props.datastoreId === "all" ? [] : [props.datastoreId]
+    ? _.set(
+        params,
+        "datastoreIds",
+        props.datastoreId === "all" ? [] : [props.datastoreId]
       )
-      : "";
+    : "";
   props.hostId
-      ? _.set(params, "resourceIds", props.hostId === "all" ? [] : [props.hostId])
-      : "";
+    ? _.set(params, "resourceIds", props.hostId === "all" ? [] : [props.hostId])
+    : "";
   _.set(params, "entityType", "HOST");
   _.set(params, "metricName", basicResourceType.value);
   _.set(params, "startTime", timestampData.value[0].getTime());
@@ -114,9 +114,9 @@ const setParams = () => {
   if (basicResourceType.value === "DATASTORE_USED_UTILIZATION") {
     _.set(params, "entityType", "DATASTORE");
     _.set(
-        params,
-        "resourceIds",
-        props.datastoreId === "all" ? [] : [props.datastoreId]
+      params,
+      "resourceIds",
+      props.datastoreId === "all" ? [] : [props.datastoreId]
     );
   }
 };
@@ -132,8 +132,8 @@ const options = computed<ECBasicOption>(() => {
   const trendInfo = apiData.value;
   const options = _.cloneDeep(defaultTrendOptions);
   let legend: any[] = [],
-      series: any = {},
-      xAxis: any[] = [];
+    series: any = {},
+    xAxis: any[] = [];
   const seriesData: any[] = [];
   if (!trendInfo || trendInfo.length === 0) {
     return {
@@ -203,11 +203,11 @@ const options = computed<ECBasicOption>(() => {
 });
 
 watch(
-    props,
-    () => {
-      getResourceTrendData();
-    },
-    { immediate: true }
+  props,
+  () => {
+    getResourceTrendData();
+  },
+  { immediate: true }
 );
 const color: Array<string> = [
   "rgb(98, 210, 85, 1)",

--- a/services/operation-analysis/frontend/src/views/base_resource_analysis/item/HostServerSpread.vue
+++ b/services/operation-analysis/frontend/src/views/base_resource_analysis/item/HostServerSpread.vue
@@ -10,10 +10,10 @@
         <div class="echarts">
           <div class="echarts-content">
             <v-chart
-                class="chart"
-                :option="option"
-                v-loading="loading"
-                autoresize
+              class="chart"
+              :option="option"
+              v-loading="loading"
+              autoresize
             />
           </div>
         </div>
@@ -38,29 +38,29 @@ const params = ref<ResourceAnalysisRequest>();
 const loading = ref<boolean>(false);
 const setParams = () => {
   props.cloudAccountId
-      ? _.set(
-          params,
-          "accountIds",
-          props.cloudAccountId === "all" ? [] : [props.cloudAccountId]
+    ? _.set(
+        params,
+        "accountIds",
+        props.cloudAccountId === "all" ? [] : [props.cloudAccountId]
       )
-      : "";
+    : "";
   props.clusterId
-      ? _.set(
-          params,
-          "clusterIds",
-          props.clusterId === "all" ? [] : [props.clusterId]
+    ? _.set(
+        params,
+        "clusterIds",
+        props.clusterId === "all" ? [] : [props.clusterId]
       )
-      : "";
+    : "";
   props.datastoreId
-      ? _.set(
-          params,
-          "datastoreIds",
-          props.datastoreId === "all" ? [] : [props.datastoreId]
+    ? _.set(
+        params,
+        "datastoreIds",
+        props.datastoreId === "all" ? [] : [props.datastoreId]
       )
-      : "";
+    : "";
   props.hostId
-      ? _.set(params, "hostIds", props.hostId === "all" ? [] : [props.hostId])
-      : "";
+    ? _.set(params, "hostIds", props.hostId === "all" ? [] : [props.hostId])
+    : "";
 };
 //获取数宿主机按云账号分布
 const apiDataStopped = ref<any>();
@@ -72,7 +72,7 @@ const getSpreadInfo = () => {
     apiDataStopped.value = res.data;
     _.set(params, "vmStatus", "running");
     ResourceSpreadViewApi.getSpreadInfo(params, loading).then(
-        (res) => (apiDataRunning.value = res.data)
+      (res) => (apiDataRunning.value = res.data)
     );
   });
 };
@@ -92,9 +92,9 @@ const data = computed<EchartsValue>(() => {
   const running: Array<number> = [];
   const stopped: Array<number> = [];
   const hosts: Array<any> = _.unionBy(
-      apiDataRunning.value?.vm,
-      apiDataRunning.value?.vm,
-      "name"
+    apiDataRunning.value?.vm,
+    apiDataRunning.value?.vm,
+    "name"
   );
   _.forEach(hosts, (v: ApiDataVO) => {
     names.push(v.name);
@@ -153,7 +153,7 @@ const option = computed<ECBasicOption>(() => {
       },
       {
         type: "inside", // 支持内部鼠标滚动平移
-        disabled:true, // 停止组件内功能
+        disabled: true, // 停止组件内功能
         start: 0,
         end: 100,
         zoomOnMouseWheel: false, // 关闭滚轮缩放
@@ -254,11 +254,11 @@ const option = computed<ECBasicOption>(() => {
   return options;
 });
 watch(
-    props,
-    () => {
-      getSpreadInfo();
-    },
-    { immediate: true }
+  props,
+  () => {
+    getSpreadInfo();
+  },
+  { immediate: true }
 );
 </script>
 <style scoped lang="scss">

--- a/services/operation-analysis/frontend/src/views/base_resource_analysis/storageList.vue
+++ b/services/operation-analysis/frontend/src/views/base_resource_analysis/storageList.vue
@@ -10,6 +10,7 @@ import {
   TableSearch,
 } from "@commons/components/ce-table/type";
 import { useI18n } from "vue-i18n";
+
 const { t } = useI18n();
 const table = ref<any>(null);
 const columns = ref([]);
@@ -83,7 +84,7 @@ onMounted(() => {
       height="100%"
       ref="table"
     >
-      <template #toolbar> </template>
+      <template #toolbar></template>
       <el-table-column type="selection" />
       <el-table-column
         :show-overflow-tooltip="true"
@@ -121,11 +122,43 @@ onMounted(() => {
         :show="false"
       ></el-table-column>
       <el-table-column prop="zone" label="集群" :show="false"></el-table-column>
-      <el-table-column prop="capacity" label="总容量(GB)"></el-table-column>
-      <el-table-column prop="allocated" label="已分配(GB)"> </el-table-column>
-      <el-table-column prop="freeSpace" label="剩余(GB)"></el-table-column>
-      <el-table-column prop="freeRate" label="剩余率(%)"></el-table-column>
-      <el-table-column prop="type" label="类型" :show="false"></el-table-column>
+      <el-table-column
+        align="right"
+        prop="capacity"
+        label="总容量(GB)"
+      ></el-table-column>
+      <el-table-column align="right" label="已使用(GB)">
+        <template #default="scope">
+          {{ scope.row.capacity - scope.row.freeSpace }}
+        </template>
+      </el-table-column>
+      <el-table-column align="right" prop="useRate" label="使用率">
+        <template #default="scope"> {{ scope.row.useRate }}% </template>
+      </el-table-column>
+      <el-table-column
+        align="right"
+        prop="freeSpace"
+        label="剩余(GB)"
+      ></el-table-column>
+      <el-table-column align="right" prop="freeRate" label="剩余率">
+        <template #default="scope"> {{ scope.row.freeRate }}% </template>
+      </el-table-column>
+      <el-table-column
+        align="right"
+        prop="allocated"
+        label="已分配(GB)"
+      ></el-table-column>
+      <el-table-column align="right" label="分配率">
+        <template #default="scope">
+          {{ (scope.row.allocated / scope.row.capacity).toFixed(2) * 100 }}%
+        </template>
+      </el-table-column>
+      <el-table-column
+        align="right"
+        prop="type"
+        label="类型"
+        :show="false"
+      ></el-table-column>
       <template #buttons>
         <CeTableColumnSelect :columns="columns" />
       </template>

--- a/services/operation-analysis/frontend/src/views/disk_analysis/diskList.vue
+++ b/services/operation-analysis/frontend/src/views/disk_analysis/diskList.vue
@@ -130,7 +130,7 @@ const tableConfig = ref<TableConfig>({
       height="100%"
       ref="table"
     >
-      <template #toolbar> </template>
+      <template #toolbar></template>
       <el-table-column type="selection" />
       <el-table-column
         min-width="150"
@@ -213,6 +213,7 @@ const tableConfig = ref<TableConfig>({
         </template>
       </el-table-column>
       <el-table-column
+        align="right"
         min-width="150"
         prop="size"
         label="大小(G)"
@@ -233,6 +234,7 @@ const tableConfig = ref<TableConfig>({
   width: 100%;
   height: calc(100vh - 270px);
 }
+
 .text-overflow {
   max-width: 100px;
   overflow: hidden;

--- a/services/operation-analysis/frontend/src/views/disk_analysis/item/DiskOrgWorkspaceSpread.vue
+++ b/services/operation-analysis/frontend/src/views/disk_analysis/item/DiskOrgWorkspaceSpread.vue
@@ -180,7 +180,7 @@ const defaultSpeedOptions = {
     },
     {
       type: "inside", // 支持内部鼠标滚动平移
-      disabled:true, // 停止组件内功能
+      disabled: true, // 停止组件内功能
       start: 0,
       end: 100,
       zoomOnMouseWheel: false, // 关闭滚轮缩放

--- a/services/operation-analysis/frontend/src/views/resource_optimization/list.vue
+++ b/services/operation-analysis/frontend/src/views/resource_optimization/list.vue
@@ -107,27 +107,59 @@
         :label="$t('commons.cloud_server.instance_type')"
       ></el-table-column>
       <el-table-column
+        align="right"
         min-width="150"
         prop="cpuAverage"
-        label="CPU平均使用率(%)"
-      ></el-table-column>
+        label="CPU平均使用率"
+      >
+        <template #default="scope">
+          {{
+            scope.row.cpuAverage ? scope.row.cpuAverage.toFixed(2) + "%" : "-"
+          }}
+        </template>
+      </el-table-column>
       <el-table-column
+        align="right"
         min-width="150"
         prop="cpuMaximum"
-        label="CPU最大使用率(%)"
+        label="CPU最大使用率"
         :show="false"
-      ></el-table-column>
+      >
+        <template #default="scope">
+          {{
+            scope.row.cpuMaximum ? scope.row.cpuMaximum.toFixed(2) + "%" : "-"
+          }}
+        </template>
+      </el-table-column>
       <el-table-column
+        align="right"
         min-width="150"
         prop="memoryAverage"
-        label="内存平均使用率(%)"
-      ></el-table-column>
+        label="内存平均使用率"
+      >
+        <template #default="scope">
+          {{
+            scope.row.memoryAverage
+              ? scope.row.memoryAverage.toFixed(2) + "%"
+              : "-"
+          }}
+        </template>
+      </el-table-column>
       <el-table-column
+        align="right"
         min-width="150"
         prop="memoryMaximum"
-        label="内存最大使用率(%)"
+        label="内存最大使用率"
         :show="false"
-      ></el-table-column>
+      >
+        <template #default="scope">
+          {{
+            scope.row.memoryMaximum
+              ? scope.row.memoryMaximum.toFixed(2) + "%"
+              : "-"
+          }}
+        </template>
+      </el-table-column>
       <template #buttons>
         <CeTableColumnSelect :columns="columns" />
       </template>

--- a/services/operation-analysis/frontend/src/views/server_analysis/item/CloudServerOrgWorkspaceSpread.vue
+++ b/services/operation-analysis/frontend/src/views/server_analysis/item/CloudServerOrgWorkspaceSpread.vue
@@ -182,7 +182,7 @@ const defaultSpeedOptions = {
     },
     {
       type: "inside", // 支持内部鼠标滚动平移
-      disabled:true, // 停止组件内功能
+      disabled: true, // 停止组件内功能
       start: 0,
       end: 100,
       zoomOnMouseWheel: false, // 关闭滚轮缩放

--- a/services/operation-analysis/frontend/src/views/server_analysis/serverList.vue
+++ b/services/operation-analysis/frontend/src/views/server_analysis/serverList.vue
@@ -180,25 +180,57 @@ const tableConfig = ref<TableConfig>({
         </template>
       </el-table-column>
       <el-table-column
+        align="right"
         min-width="150"
         prop="cpuAverage"
-        label="CPU平均使用率(%)"
-      ></el-table-column>
+        label="CPU平均使用率"
+      >
+        <template #default="scope">
+          {{
+            scope.row.cpuAverage ? scope.row.cpuAverage.toFixed(2) + "%" : "-"
+          }}
+        </template>
+      </el-table-column>
       <el-table-column
+        align="right"
         min-width="150"
         prop="cpuMaximum"
-        label="CPU最大使用率(%)"
-      ></el-table-column>
+        label="CPU最大使用率"
+      >
+        <template #default="scope">
+          {{
+            scope.row.cpuMaximum ? scope.row.cpuMaximum.toFixed(2) + "%" : "-"
+          }}
+        </template>
+      </el-table-column>
       <el-table-column
+        align="right"
         min-width="150"
         prop="memoryAverage"
-        label="内存平均使用率(%)"
-      ></el-table-column>
+        label="内存平均使用率"
+      >
+        <template #default="scope">
+          {{
+            scope.row.memoryAverage
+              ? scope.row.memoryAverage.toFixed(2) + "%"
+              : "-"
+          }}
+        </template>
+      </el-table-column>
       <el-table-column
+        align="right"
         min-width="150"
         prop="memoryMaximum"
-        label="内存最大使用率(%)"
-      ></el-table-column>
+        label="内存最大使用率"
+      >
+        <template #default="scope">
+          {{
+            scope.row.memoryMaximum
+              ? scope.row.memoryMaximum.toFixed(2) + "%"
+              : "-"
+          }}
+        </template>
+      </el-table-column>
       <template #buttons>
         <CeTableColumnSelect :columns="columns" />
       </template>


### PR DESCRIPTION
1.宿主机明细列表增加 CPU总量（MHz）、CPU已使用 、内存已使用（GB）issues #68 
2.运营分析-显示样式优化 issues #28 
所有资源明细列表（宿主机、存储器、云主机、磁盘明细）的 使用率字段样式优化：
1、列表的标题字段：
去掉（%）只显示指标字段名称。
2、列表的数据值：显示统一的小数点保留位数、建议统一右对齐。
3、没有数据的显示 -