### PR TITLE
fix(vm-service,sdk): 云主机列表查询问题；创建华为云主机，规格列表输入条件代入查询

### DIFF
--- a/framework/sdk/frontend/commons/components/ce-form/items/huawei/HuaweiInstanceSpecForm.vue
+++ b/framework/sdk/frontend/commons/components/ce-form/items/huawei/HuaweiInstanceSpecForm.vue
@@ -172,6 +172,7 @@ function getList() {
         selectRowId.value = undefined;
         currentRow.value = undefined;
       }
+      handleQueryClick();
       emit("change");
     });
 }

--- a/services/vm-service/backend/src/main/java/com/fit2cloud/service/impl/VmCloudServerServiceImpl.java
+++ b/services/vm-service/backend/src/main/java/com/fit2cloud/service/impl/VmCloudServerServiceImpl.java
@@ -138,8 +138,16 @@ public class VmCloudServerServiceImpl extends ServiceImpl<BaseVmCloudServerMappe
     @Override
     public IPage<VmCloudServerDTO> pageVmCloudServer(PageVmCloudServerRequest request) {
         setCurrentInfos(request);
-
-        Page<VmCloudServerDTO> page = PageUtil.of(request, VmCloudServerDTO.class, new OrderItem(ColumnNameUtil.getColumnName(VmCloudServerDTO::getCreateTime, true), false), true);
+        List<OrderItem> orderItemList = new ArrayList<>();
+        if (Objects.nonNull(request.getOrder())) {
+            orderItemList.add(request.getOrder());
+        } else {
+            orderItemList.add(new OrderItem(ColumnNameUtil.getColumnName(VmCloudServerDTO::getCreateTime, true), false));
+        }
+        // 加上唯一的ID,不然order by会错乱
+        orderItemList.add(new OrderItem(ColumnNameUtil.getColumnName(VmCloudServerDTO::getId, true), true));
+        Page<VmCloudServerDTO> page = PageUtil.of(request, VmCloudServerDTO.class, true);
+        page.setOrders(orderItemList);
         // 构建查询参数
         QueryWrapper<VmCloudServerDTO> wrapper = addQuery(request);
         return vmCloudServerMapper.pageVmCloudServer(page, wrapper);

--- a/services/vm-service/frontend/src/views/vm_cloud_server/list.vue
+++ b/services/vm-service/frontend/src/views/vm_cloud_server/list.vue
@@ -983,14 +983,6 @@ const moreActions = ref<Array<ButtonAction>>([
       min-width="120px"
       :show="false"
     ></el-table-column>
-    <el-table-column
-      prop="deleteTime"
-      column-key="deleteTime"
-      sortable
-      :label="$t('commons.delete_time', '删除时间')"
-      :show="false"
-      min-width="180px"
-    ></el-table-column>
     <fu-table-operations
       :ellipsis="2"
       :columns="columns"


### PR DESCRIPTION
#### What this PR does / why we need it?
1.云主机列表前一页的最后一条记录会重复出现在后一页的第一条
2.创建华为云主机时，切换可用区后，使用已输入的查询条件进行过滤
#### Summary of your change

#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.