### PR TITLE
[运营分析]明细列表添加字段，以及显示优化

### DIFF
--- a/services/operation-analysis/backend/src/main/java/com/fit2cloud/service/impl/BaseResourceAnalysisServiceImpl.java
+++ b/services/operation-analysis/backend/src/main/java/com/fit2cloud/service/impl/BaseResourceAnalysisServiceImpl.java
@@ -122,7 +122,7 @@ public class BaseResourceAnalysisServiceImpl implements IBaseResourceAnalysisSer
         IPage<AnalysisDatastoreDTO> result = baseVmCloudDatastoreMapper.selectJoinPage(page, AnalysisDatastoreDTO.class, wrapper);
         //计算
         result.getRecords().forEach(v -> {
-            v.setAllocated(String.valueOf(v.getCapacity() - v.getFreeSpace()));
+            v.setAllocated(String.valueOf(v.getAllocatedSpace()));
             BigDecimal useRate = new BigDecimal(v.getCapacity()).subtract(new BigDecimal(v.getFreeSpace())).multiply(new BigDecimal(100)).divide(new BigDecimal(v.getCapacity()), 2, RoundingMode.UP);
             v.setUseRate(String.valueOf(useRate));
             BigDecimal freeRate = new BigDecimal(v.getFreeSpace()).multiply(new BigDecimal(100)).divide(new BigDecimal(v.getCapacity()), 2, RoundingMode.UP);
@@ -235,8 +235,9 @@ public class BaseResourceAnalysisServiceImpl implements IBaseResourceAnalysisSer
         List<VmCloudHost> hosts = getVmHost(request);
         if (CollectionUtils.isNotEmpty(hosts)) {
             hosts = hosts.stream().filter(v -> !CollectionUtils.isNotEmpty(request.getHostIds()) || request.getHostIds().contains(v.getId())).toList();
-            BigDecimal cpuTotal = new BigDecimal(hosts.stream().filter(v -> Objects.nonNull(v.getCpuTotal())).mapToLong(VmCloudHost::getCpuTotal).sum());
-            BigDecimal cpuAllocated = new BigDecimal(hosts.stream().filter(v -> Objects.nonNull(v.getCpuAllocated())).mapToLong(VmCloudHost::getCpuAllocated).sum());
+            // 取core
+            BigDecimal cpuTotal = new BigDecimal(hosts.stream().filter(v -> Objects.nonNull(v.getNumCpuCores())).mapToLong(VmCloudHost::getNumCpuCores).sum());
+            BigDecimal cpuAllocated = new BigDecimal(hosts.stream().filter(v -> Objects.nonNull(v.getVmCpuCores())).mapToLong(VmCloudHost::getVmCpuCores).sum());
             BigDecimal cpuAllocatedRate = cpuAllocated.divide(cpuTotal, 2, RoundingMode.HALF_UP).multiply(new BigDecimal(100));
             result.put(SpecialAttributesConstants.ResourceField.CPU, ResourceAllocatedInfo.builder()
                     .total(cpuTotal)
@@ -258,7 +259,7 @@ public class BaseResourceAnalysisServiceImpl implements IBaseResourceAnalysisSer
             datastoreList = datastoreList.stream().filter(v -> !CollectionUtils.isNotEmpty(request.getDatastoreIds()) || request.getDatastoreIds().contains(v.getId())).toList();
             BigDecimal capacity = new BigDecimal(datastoreList.stream().filter(v -> Objects.nonNull(v.getCapacity())).mapToLong(VmCloudDatastore::getCapacity).sum());
             BigDecimal allocatedSpace = new BigDecimal(datastoreList.stream().filter(v -> Objects.nonNull(v.getAllocatedSpace())).mapToLong(VmCloudDatastore::getAllocatedSpace).sum());
-            BigDecimal memoryAllocatedRate = capacity.subtract(allocatedSpace).divide(capacity, 2, RoundingMode.HALF_UP).multiply(new BigDecimal(100));
+            BigDecimal memoryAllocatedRate = allocatedSpace.divide(capacity, 2, RoundingMode.HALF_UP).multiply(new BigDecimal(100));
             result.put(SpecialAttributesConstants.ResourceField.DATASTORE, ResourceAllocatedInfo.builder()
                     .total(capacity)
                     .allocated(allocatedSpace)
@@ -477,6 +478,7 @@ public class BaseResourceAnalysisServiceImpl implements IBaseResourceAnalysisSer
             result.put("memory", ResourceAllocatedInfo.builder()
                     .total(memoryTotal.divide(new BigDecimal(1024), RoundingMode.HALF_UP))
                     .allocated(memoryUsedRate.divide(new BigDecimal(1024), RoundingMode.HALF_UP))
+                    .used(memoryUsed)
                     .usedRate(memoryUsedRate.compareTo(new BigDecimal(100)) > 0 ? new BigDecimal(100) : memoryUsedRate)
                     .build());
 

--- a/services/operation-analysis/frontend/src/views/base_resource_analysis/hostList.vue
+++ b/services/operation-analysis/frontend/src/views/base_resource_analysis/hostList.vue
@@ -135,6 +135,10 @@ onMounted(() => {
       ></el-table-column>
       <el-table-column prop="vmCpuCores" label="CPU已分配(核)" min-width="150">
       </el-table-column>
+      <el-table-column prop="cpuTotal" label="CPU总量(MHz)" min-width="150">
+      </el-table-column>
+      <el-table-column prop="cpuUsed" label="CPU已使用(MHz)" min-width="150">
+      </el-table-column>
       <el-table-column prop="memoryTotal" label="内存总量(GB)" min-width="150">
         <template #default="scope">
           {{ (scope.row.memoryTotal / 1024).toFixed(2) }}
@@ -147,6 +151,11 @@ onMounted(() => {
       >
         <template #default="scope">
           {{ (scope.row.memoryAllocated / 1024).toFixed(2) }}
+        </template>
+      </el-table-column>
+      <el-table-column prop="cpuUsed" label="内存已使用(GB)" min-width="150">
+        <template #default="scope">
+          {{ (scope.row.cpuUsed / 1024).toFixed(2) }}
         </template>
       </el-table-column>
       <el-table-column

--- a/services/operation-analysis/frontend/src/views/base_resource_analysis/hostList.vue
+++ b/services/operation-analysis/frontend/src/views/base_resource_analysis/hostList.vue
@@ -10,6 +10,7 @@ import {
   TableSearch,
 } from "@commons/components/ce-table/type";
 import { useI18n } from "vue-i18n";
+
 const { t } = useI18n();
 const table = ref<any>(null);
 const columns = ref([]);
@@ -83,7 +84,7 @@ onMounted(() => {
       height="100%"
       ref="table"
     >
-      <template #toolbar> </template>
+      <template #toolbar></template>
       <el-table-column type="selection" />
       <el-table-column
         :show-overflow-tooltip="true"
@@ -122,24 +123,74 @@ onMounted(() => {
         label="数据中心"
         :show="false"
       ></el-table-column>
-      <el-table-column prop="zone" label="集群" :show="false"></el-table-column>
+      <el-table-column prop="zone" label="集群" :show="false">
+      </el-table-column>
       <el-table-column
         prop="hostIp"
         label="IP地址"
         :show="false"
       ></el-table-column>
       <el-table-column
+        align="right"
         prop="numCpuCores"
         label="CPU总量(核)"
         width="120"
       ></el-table-column>
-      <el-table-column prop="vmCpuCores" label="CPU已分配(核)" min-width="150">
+      <el-table-column
+        align="right"
+        prop="vmCpuCores"
+        label="CPU已分配(核)"
+        min-width="150"
+      >
       </el-table-column>
-      <el-table-column prop="cpuTotal" label="CPU总量(MHz)" min-width="150">
+      <el-table-column
+        :show="false"
+        align="right"
+        prop="memoryTotal"
+        label="CPU分配率"
+        min-width="150"
+      >
+        <template #default="scope">
+          {{ (scope.row.vmCpuCores / scope.row.numCpuCores).toFixed(2) * 100 }}%
+        </template>
       </el-table-column>
-      <el-table-column prop="cpuUsed" label="CPU已使用(MHz)" min-width="150">
+      <el-table-column
+        align="right"
+        prop="cpuTotal"
+        label="CPU总量(MHz)"
+        min-width="150"
+      >
       </el-table-column>
-      <el-table-column prop="memoryTotal" label="内存总量(GB)" min-width="150">
+      <el-table-column
+        align="right"
+        prop="cpuUsed"
+        label="CPU已使用(MHz)"
+        min-width="150"
+      >
+        <template #default="scope">
+          {{ scope.row.cpuUsed ? scope.row.cpuUsed : "-" }}
+        </template>
+      </el-table-column>
+      <el-table-column
+        :show="false"
+        align="right"
+        label="CPU使用率"
+        min-width="150"
+      >
+        <template #default="scope">
+          {{
+            scope.row.cpuUsed
+              ? (scope.row.cpuUsed / scope.row.cpuTotal).toFixed(2) * 100 + "%"
+              : "-"
+          }}
+        </template>
+      </el-table-column>
+      <el-table-column
+        align="right"
+        prop="memoryTotal"
+        label="内存总量(GB)"
+        min-width="150"
+      >
         <template #default="scope">
           {{ (scope.row.memoryTotal / 1024).toFixed(2) }}
         </template>
@@ -148,22 +199,64 @@ onMounted(() => {
         prop="memoryAllocated"
         label="内存已分配(GB)"
         min-width="150"
+        align="right"
       >
         <template #default="scope">
           {{ (scope.row.memoryAllocated / 1024).toFixed(2) }}
         </template>
       </el-table-column>
-      <el-table-column prop="cpuUsed" label="内存已使用(GB)" min-width="150">
+      <el-table-column
+        :show="false"
+        align="right"
+        prop="memoryTotal"
+        label="内存分配率"
+        min-width="150"
+      >
         <template #default="scope">
-          {{ (scope.row.cpuUsed / 1024).toFixed(2) }}
+          {{
+            (scope.row.memoryAllocated / scope.row.memoryTotal).toFixed(2) *
+            100
+          }}%
         </template>
       </el-table-column>
       <el-table-column
+        align="right"
+        prop="memoryUsed"
+        label="内存已使用(GB)"
+        min-width="150"
+      >
+        <template #default="scope">
+          {{
+            scope.row.memoryUsed
+              ? (scope.row.memoryUsed / 1024).toFixed(2)
+              : "-"
+          }}
+        </template>
+      </el-table-column>
+      <el-table-column
+        :show="false"
+        align="right"
+        label="内存使用率"
+        min-width="150"
+      >
+        <template #default="scope">
+          {{
+            scope.row.memoryUsed
+              ? (scope.row.memoryUsed / scope.row.memoryTotal).toFixed(2) *
+                  100 +
+                "%"
+              : "-"
+          }}
+        </template>
+      </el-table-column>
+      <el-table-column
+        align="right"
         prop="vmTotal"
         label="云主机总数"
         min-width="150"
       ></el-table-column>
       <el-table-column
+        align="right"
         prop="vmRunning"
         label="运行中云主机"
         min-width="150"

--- a/services/operation-analysis/frontend/src/views/base_resource_analysis/item/HostServerSpread.vue
+++ b/services/operation-analysis/frontend/src/views/base_resource_analysis/item/HostServerSpread.vue
@@ -153,7 +153,7 @@ const option = computed<ECBasicOption>(() => {
       },
       {
         type: "inside", // 支持内部鼠标滚动平移
-        disabled:true, // 停止组件内功能
+        disabled: true, // 停止组件内功能
         start: 0,
         end: 100,
         zoomOnMouseWheel: false, // 关闭滚轮缩放

--- a/services/operation-analysis/frontend/src/views/base_resource_analysis/storageList.vue
+++ b/services/operation-analysis/frontend/src/views/base_resource_analysis/storageList.vue
@@ -10,6 +10,7 @@ import {
   TableSearch,
 } from "@commons/components/ce-table/type";
 import { useI18n } from "vue-i18n";
+
 const { t } = useI18n();
 const table = ref<any>(null);
 const columns = ref([]);
@@ -83,7 +84,7 @@ onMounted(() => {
       height="100%"
       ref="table"
     >
-      <template #toolbar> </template>
+      <template #toolbar></template>
       <el-table-column type="selection" />
       <el-table-column
         :show-overflow-tooltip="true"
@@ -121,11 +122,43 @@ onMounted(() => {
         :show="false"
       ></el-table-column>
       <el-table-column prop="zone" label="集群" :show="false"></el-table-column>
-      <el-table-column prop="capacity" label="总容量(GB)"></el-table-column>
-      <el-table-column prop="allocated" label="已分配(GB)"> </el-table-column>
-      <el-table-column prop="freeSpace" label="剩余(GB)"></el-table-column>
-      <el-table-column prop="freeRate" label="剩余率(%)"></el-table-column>
-      <el-table-column prop="type" label="类型" :show="false"></el-table-column>
+      <el-table-column
+        align="right"
+        prop="capacity"
+        label="总容量(GB)"
+      ></el-table-column>
+      <el-table-column align="right" label="已使用(GB)">
+        <template #default="scope">
+          {{ scope.row.capacity - scope.row.freeSpace }}
+        </template>
+      </el-table-column>
+      <el-table-column align="right" prop="useRate" label="使用率">
+        <template #default="scope"> {{ scope.row.useRate }}% </template>
+      </el-table-column>
+      <el-table-column
+        align="right"
+        prop="freeSpace"
+        label="剩余(GB)"
+      ></el-table-column>
+      <el-table-column align="right" prop="freeRate" label="剩余率">
+        <template #default="scope"> {{ scope.row.freeRate }}% </template>
+      </el-table-column>
+      <el-table-column
+        align="right"
+        prop="allocated"
+        label="已分配(GB)"
+      ></el-table-column>
+      <el-table-column align="right" label="分配率">
+        <template #default="scope">
+          {{ (scope.row.allocated / scope.row.capacity).toFixed(2) * 100 }}%
+        </template>
+      </el-table-column>
+      <el-table-column
+        align="right"
+        prop="type"
+        label="类型"
+        :show="false"
+      ></el-table-column>
       <template #buttons>
         <CeTableColumnSelect :columns="columns" />
       </template>

--- a/services/operation-analysis/frontend/src/views/disk_analysis/diskList.vue
+++ b/services/operation-analysis/frontend/src/views/disk_analysis/diskList.vue
@@ -130,7 +130,7 @@ const tableConfig = ref<TableConfig>({
       height="100%"
       ref="table"
     >
-      <template #toolbar> </template>
+      <template #toolbar></template>
       <el-table-column type="selection" />
       <el-table-column
         min-width="150"
@@ -213,6 +213,7 @@ const tableConfig = ref<TableConfig>({
         </template>
       </el-table-column>
       <el-table-column
+        align="right"
         min-width="150"
         prop="size"
         label="大小(G)"
@@ -233,6 +234,7 @@ const tableConfig = ref<TableConfig>({
   width: 100%;
   height: calc(100vh - 270px);
 }
+
 .text-overflow {
   max-width: 100px;
   overflow: hidden;

--- a/services/operation-analysis/frontend/src/views/disk_analysis/item/DiskOrgWorkspaceSpread.vue
+++ b/services/operation-analysis/frontend/src/views/disk_analysis/item/DiskOrgWorkspaceSpread.vue
@@ -180,7 +180,7 @@ const defaultSpeedOptions = {
     },
     {
       type: "inside", // 支持内部鼠标滚动平移
-      disabled:true, // 停止组件内功能
+      disabled: true, // 停止组件内功能
       start: 0,
       end: 100,
       zoomOnMouseWheel: false, // 关闭滚轮缩放

--- a/services/operation-analysis/frontend/src/views/resource_optimization/list.vue
+++ b/services/operation-analysis/frontend/src/views/resource_optimization/list.vue
@@ -107,27 +107,59 @@
         :label="$t('commons.cloud_server.instance_type')"
       ></el-table-column>
       <el-table-column
+        align="right"
         min-width="150"
         prop="cpuAverage"
-        label="CPU平均使用率(%)"
-      ></el-table-column>
+        label="CPU平均使用率"
+      >
+        <template #default="scope">
+          {{
+            scope.row.cpuAverage ? scope.row.cpuAverage.toFixed(2) + "%" : "-"
+          }}
+        </template>
+      </el-table-column>
       <el-table-column
+        align="right"
         min-width="150"
         prop="cpuMaximum"
-        label="CPU最大使用率(%)"
+        label="CPU最大使用率"
         :show="false"
-      ></el-table-column>
+      >
+        <template #default="scope">
+          {{
+            scope.row.cpuMaximum ? scope.row.cpuMaximum.toFixed(2) + "%" : "-"
+          }}
+        </template>
+      </el-table-column>
       <el-table-column
+        align="right"
         min-width="150"
         prop="memoryAverage"
-        label="内存平均使用率(%)"
-      ></el-table-column>
+        label="内存平均使用率"
+      >
+        <template #default="scope">
+          {{
+            scope.row.memoryAverage
+              ? scope.row.memoryAverage.toFixed(2) + "%"
+              : "-"
+          }}
+        </template>
+      </el-table-column>
       <el-table-column
+        align="right"
         min-width="150"
         prop="memoryMaximum"
-        label="内存最大使用率(%)"
+        label="内存最大使用率"
         :show="false"
-      ></el-table-column>
+      >
+        <template #default="scope">
+          {{
+            scope.row.memoryMaximum
+              ? scope.row.memoryMaximum.toFixed(2) + "%"
+              : "-"
+          }}
+        </template>
+      </el-table-column>
       <template #buttons>
         <CeTableColumnSelect :columns="columns" />
       </template>

--- a/services/operation-analysis/frontend/src/views/server_analysis/item/CloudServerOrgWorkspaceSpread.vue
+++ b/services/operation-analysis/frontend/src/views/server_analysis/item/CloudServerOrgWorkspaceSpread.vue
@@ -182,7 +182,7 @@ const defaultSpeedOptions = {
     },
     {
       type: "inside", // 支持内部鼠标滚动平移
-      disabled:true, // 停止组件内功能
+      disabled: true, // 停止组件内功能
       start: 0,
       end: 100,
       zoomOnMouseWheel: false, // 关闭滚轮缩放

--- a/services/operation-analysis/frontend/src/views/server_analysis/serverList.vue
+++ b/services/operation-analysis/frontend/src/views/server_analysis/serverList.vue
@@ -180,25 +180,57 @@ const tableConfig = ref<TableConfig>({
         </template>
       </el-table-column>
       <el-table-column
+        align="right"
         min-width="150"
         prop="cpuAverage"
-        label="CPU平均使用率(%)"
-      ></el-table-column>
+        label="CPU平均使用率"
+      >
+        <template #default="scope">
+          {{
+            scope.row.cpuAverage ? scope.row.cpuAverage.toFixed(2) + "%" : "-"
+          }}
+        </template>
+      </el-table-column>
       <el-table-column
+        align="right"
         min-width="150"
         prop="cpuMaximum"
-        label="CPU最大使用率(%)"
-      ></el-table-column>
+        label="CPU最大使用率"
+      >
+        <template #default="scope">
+          {{
+            scope.row.cpuMaximum ? scope.row.cpuMaximum.toFixed(2) + "%" : "-"
+          }}
+        </template>
+      </el-table-column>
       <el-table-column
+        align="right"
         min-width="150"
         prop="memoryAverage"
-        label="内存平均使用率(%)"
-      ></el-table-column>
+        label="内存平均使用率"
+      >
+        <template #default="scope">
+          {{
+            scope.row.memoryAverage
+              ? scope.row.memoryAverage.toFixed(2) + "%"
+              : "-"
+          }}
+        </template>
+      </el-table-column>
       <el-table-column
+        align="right"
         min-width="150"
         prop="memoryMaximum"
-        label="内存最大使用率(%)"
-      ></el-table-column>
+        label="内存最大使用率"
+      >
+        <template #default="scope">
+          {{
+            scope.row.memoryMaximum
+              ? scope.row.memoryMaximum.toFixed(2) + "%"
+              : "-"
+          }}
+        </template>
+      </el-table-column>
       <template #buttons>
         <CeTableColumnSelect :columns="columns" />
       </template>


### PR DESCRIPTION
1.宿主机明细列表增加 CPU总量（MHz）、CPU已使用 、内存已使用（GB）issues https://github.com/CloudExplorer-Dev/CloudExplorer-Lite/issues/68
2.运营分析-显示样式优化 issues https://github.com/CloudExplorer-Dev/CloudExplorer-Lite/issues/28
所有资源明细列表（宿主机、存储器、云主机、磁盘明细）的 使用率字段样式优化：
1、列表的标题字段：
去掉（%）只显示指标字段名称。
2、列表的数据值：显示统一的小数点保留位数、建议统一右对齐。
3、没有数据的显示 -