### PR TITLE
fix(vm-service sdk): 公有云云主机查询监控数据逻辑调整，优先查询Agent监控数据

### DIFF
--- a/framework/sdk/backend/src/main/java/com/fit2cloud/service/PerfMonitorService.java
+++ b/framework/sdk/backend/src/main/java/com/fit2cloud/service/PerfMonitorService.java
@@ -133,10 +133,6 @@ public class PerfMonitorService {
         List<QueryUtil.QueryCondition> queryConditions = elasticsearchProvide.getDefaultQueryConditions(List.of(request.getCloudAccountId()), request.getMetricName(), request.getEntityType(), request.getStartTime(), request.getEndTime());
         QueryUtil.QueryCondition instanceId = new QueryUtil.QueryCondition(true, "instanceId.keyword", request.getInstanceId(), QueryUtil.CompareType.EQ);
         queryConditions.add(instanceId);
-        QueryUtil.QueryCondition metricName = new QueryUtil.QueryCondition(true, "metricName.keyword", request.getMetricName(), QueryUtil.CompareType.EQ);
-        queryConditions.add(metricName);
-        QueryUtil.QueryCondition accountId = new QueryUtil.QueryCondition(true, "cloudAccountId.keyword", request.getCloudAccountId(), QueryUtil.CompareType.EQ);
-        queryConditions.add(accountId);
         BoolQuery.Builder boolQuery = QueryUtil.getQuery(queryConditions);
         ///TODO 这个地方到时候可能要改，ES一次只能查询10000条数据，如果查询一年的监控数据，这里可能需要调整
         NativeQueryBuilder query = new NativeQueryBuilder()

--- a/services/vm-service/backend/src/main/java/com/fit2cloud/provider/entity/F2CVirtualMachine.java
+++ b/services/vm-service/backend/src/main/java/com/fit2cloud/provider/entity/F2CVirtualMachine.java
@@ -225,4 +225,9 @@ public class F2CVirtualMachine {
      * 安全组IDS
      */
     private List<String> securityGroupIds;
+
+    /**
+     * 监控插件(Agent)状态为运行中
+     */
+    private boolean agentRunning;
 }

--- a/services/vm-service/backend/src/main/java/com/fit2cloud/provider/impl/aliyun/AliyunCloudProvider.java
+++ b/services/vm-service/backend/src/main/java/com/fit2cloud/provider/impl/aliyun/AliyunCloudProvider.java
@@ -368,7 +368,7 @@ public class AliyunCloudProvider extends AbstractCloudProvider<AliyunVmCredentia
 
     @Override
     public List<F2CPerfMetricMonitorData> getF2CDiskPerfMetricMonitorData(String req) {
-        return AliyunSyncCloudApi.getF2CDiskPerfMetricList(JsonUtil.parseObject(req, GetMetricsRequest.class));
+        return new ArrayList<>();
     }
 
     @Override

--- a/services/vm-service/backend/src/main/java/com/fit2cloud/provider/impl/aliyun/api/AliyunSyncCloudApi.java
+++ b/services/vm-service/backend/src/main/java/com/fit2cloud/provider/impl/aliyun/api/AliyunSyncCloudApi.java
@@ -1,8 +1,7 @@
 package com.fit2cloud.provider.impl.aliyun.api;
 
 import com.aliyun.bssopenapi20171214.models.*;
-import com.aliyun.cms20190101.models.DescribeMetricListRequest;
-import com.aliyun.cms20190101.models.DescribeMetricListResponse;
+import com.aliyun.cms20190101.models.*;
 import com.aliyun.ecs20140526.Client;
 import com.aliyun.ecs20140526.models.CreateInstanceRequest;
 import com.aliyun.ecs20140526.models.CreateInstanceResponse;
@@ -12,6 +11,7 @@ import com.aliyun.teautil.models.RuntimeOptions;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fit2cloud.common.constants.Language;
 import com.fit2cloud.common.exception.Fit2cloudException;
+import com.fit2cloud.common.log.utils.LogUtil;
 import com.fit2cloud.common.provider.entity.F2CEntityType;
 import com.fit2cloud.common.provider.entity.F2CPerfMetricMonitorData;
 import com.fit2cloud.common.provider.exception.ReTryException;
@@ -35,6 +35,7 @@ import com.fit2cloud.provider.impl.aliyun.entity.AliyunInstanceType;
 import com.fit2cloud.provider.impl.aliyun.entity.credential.AliyunVmCredential;
 import com.fit2cloud.provider.impl.aliyun.entity.request.*;
 import com.fit2cloud.provider.impl.aliyun.util.AliyunMappingUtil;
+import com.google.common.base.Joiner;
 import com.google.gson.Gson;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -1182,11 +1183,13 @@ public class AliyunSyncCloudApi {
         }
         List<F2CPerfMetricMonitorData> result = new ArrayList<>();
         //设置时间，根据syncTimeStampStr,默认一个小时
-        getMetricsRequest.setStartTime(String.valueOf(DateUtil.beforeOneHourToTimestamp(Long.valueOf(getMetricsRequest.getSyncTimeStampStr()))));
+        Long startTime = DateUtil.beforeOneHourToTimestamp(Long.valueOf(getMetricsRequest.getSyncTimeStampStr()));
+        //多获取过去30分钟的数据，防止同步线程时间不固定，导致数据不全的问题
+        getMetricsRequest.setStartTime(String.valueOf(startTime - 1800000L));
         getMetricsRequest.setEndTime(getMetricsRequest.getSyncTimeStampStr());
         try {
             getMetricsRequest.setRegionId(getMetricsRequest.getRegionId());
-            result.addAll(getVmPerfMetric(getMetricsRequest));
+            result.addAll(getVmPerfMetricMonitorData(getMetricsRequest));
         } catch (Exception e) {
             e.printStackTrace();
             throw new SkipPageException(100021, "获取监控数据失败-" + getMetricsRequest.getRegionId() + "-" + e.getMessage());
@@ -1194,80 +1197,6 @@ public class AliyunSyncCloudApi {
         return result;
     }
 
-    /**
-     * TODO 未实现
-     *
-     * @param getMetricsRequest
-     * @return
-     */
-    public static List<F2CPerfMetricMonitorData> getF2CDiskPerfMetricList(GetMetricsRequest getMetricsRequest) {
-        if (StringUtils.isEmpty(getMetricsRequest.getRegionId())) {
-            throw new Fit2cloudException(10002, "区域为必填参数");
-        }
-        List<F2CPerfMetricMonitorData> result = new ArrayList<>();
-        //设置时间，根据syncTimeStampStr,默认一个小时
-        getMetricsRequest.setStartTime(String.valueOf(DateUtil.beforeOneHourToTimestamp(Long.valueOf(getMetricsRequest.getSyncTimeStampStr()))));
-        getMetricsRequest.setEndTime(getMetricsRequest.getSyncTimeStampStr());
-        try {
-            getMetricsRequest.setRegionId(getMetricsRequest.getRegionId());
-            // result.addAll(getDiskPerfMetric(getMetricsRequest));
-        } catch (Exception e) {
-            SkipPageException.throwSkipPageException(e);
-            throw new Fit2cloudException(100021, "获取监控数据失败-" + getMetricsRequest.getRegionId() + "-" + e.getMessage());
-        }
-        return result;
-    }
-
-    private static List<F2CPerfMetricMonitorData> getDiskPerfMetric(GetMetricsRequest getMetricsRequest) {
-        AliyunVmCredential credential = JsonUtil.parseObject(getMetricsRequest.getCredential(), AliyunVmCredential.class);
-        List<F2CPerfMetricMonitorData> result = new ArrayList<>();
-        //查询所有云盘
-        ListDisksRequest listDisksRequest = new ListDisksRequest();
-        listDisksRequest.setCredential(getMetricsRequest.getCredential());
-        listDisksRequest.setRegionId(getMetricsRequest.getRegionId());
-        List<F2CDisk> disks = listDisk(listDisksRequest);
-        if (disks.size() == 0) {
-            return result;
-        }
-        //查询监控指标数据参数
-        ///TODO 由于我们只查询一个小时内的数据，时间间隔是60s,所以查询每台机器的监控数据的时候最多不过60条数据，所以不需要分页查询
-        Map<String, String> dimension = new HashMap<>();
-        DescribeMetricListRequest describeMetricListRequest = new DescribeMetricListRequest()
-                .setNamespace("acs_ecs_dashboard")
-                .setPeriod(String.valueOf(getMetricsRequest.getPeriod()))
-                .setEndTime(getMetricsRequest.getEndTime())
-                .setStartTime(getMetricsRequest.getStartTime())
-                .setRegionId(getMetricsRequest.getRegionId());
-        com.aliyun.cms20190101.Client cmsClient = credential.getCmsClientByRegion(getMetricsRequest.getRegionId());
-        disks.forEach(disk -> {
-            dimension.put("instanceId", disk.getInstanceUuid());
-            //监控指标
-            Arrays.stream(AliyunPerfMetricConstants.CloudDiskPerfMetricEnum.values()).sorted().collect(Collectors.toList()).forEach(perfMetric -> {
-                describeMetricListRequest.setDimensions(JsonUtil.toJSONString(Arrays.asList(dimension)));
-                describeMetricListRequest.setMetricName(perfMetric.getMetricName());
-                try {
-                    //查询监控指标数据
-                    DescribeMetricListResponse response = cmsClient.describeMetricListWithOptions(describeMetricListRequest, new RuntimeOptions());
-                    if (StringUtils.equalsIgnoreCase(response.getBody().getCode(), "200") && !StringUtils.isBlank(response.getBody().getDatapoints())) {
-                        ArrayNode jsonArray = JsonUtil.parseArray(response.getBody().getDatapoints());
-                        jsonArray.forEach(v -> {
-                            F2CPerfMetricMonitorData f2CEntityPerfMetric = AliyunMappingUtil.toF2CPerfMetricMonitorData(v);
-                            f2CEntityPerfMetric.setEntityType(F2CEntityType.DISK.name());
-                            f2CEntityPerfMetric.setMetricName(perfMetric.name());
-                            f2CEntityPerfMetric.setPeriod(getMetricsRequest.getPeriod());
-                            f2CEntityPerfMetric.setInstanceId(disk.getDiskId());
-                            f2CEntityPerfMetric.setUnit(perfMetric.getUnit());
-                            result.add(f2CEntityPerfMetric);
-                        });
-                    }
-                } catch (Exception e) {
-                    e.printStackTrace();
-                }
-            });
-
-        });
-        return result;
-    }
 
     /**
      * 获取虚拟机监控指标数据
@@ -1275,57 +1204,105 @@ public class AliyunSyncCloudApi {
      * @param getMetricsRequest
      * @return
      */
-    private static List<F2CPerfMetricMonitorData> getVmPerfMetric(GetMetricsRequest getMetricsRequest) {
-        AliyunVmCredential credential = JsonUtil.parseObject(getMetricsRequest.getCredential(), AliyunVmCredential.class);
+    private static List<F2CPerfMetricMonitorData> getVmPerfMetricMonitorData(GetMetricsRequest getMetricsRequest) {
         List<F2CPerfMetricMonitorData> result = new ArrayList<>();
-        //查询所有虚拟机
-        ListVirtualMachineRequest listVirtualMachineRequest = new ListVirtualMachineRequest();
-        listVirtualMachineRequest.setCredential(getMetricsRequest.getCredential());
-        listVirtualMachineRequest.setRegion(getMetricsRequest.getRegionId());
-        List<F2CVirtualMachine> vms = listVirtualMachine(listVirtualMachineRequest);
+        List<F2CVirtualMachine> vms = getRegionAllVms(getMetricsRequest.getCredential(), getMetricsRequest.getRegionId());
         if (vms.size() == 0) {
             return result;
         }
-        //查询监控指标数据参数
-        ///TODO 由于我们只查询一个小时内的数据，时间间隔是60s,所以查询每台机器的监控数据的时候最多不过60条数据，所以不需要分页查询
-        Map<String, String> dimension = new HashMap<>();
         DescribeMetricListRequest describeMetricListRequest = new DescribeMetricListRequest()
                 .setNamespace("acs_ecs_dashboard")
                 .setPeriod(String.valueOf(getMetricsRequest.getPeriod()))
                 .setEndTime(getMetricsRequest.getEndTime())
                 .setStartTime(getMetricsRequest.getStartTime())
                 .setRegionId(getMetricsRequest.getRegionId());
+        AliyunVmCredential credential = JsonUtil.parseObject(getMetricsRequest.getCredential(), AliyunVmCredential.class);
         com.aliyun.cms20190101.Client cmsClient = credential.getCmsClientByRegion(getMetricsRequest.getRegionId());
+        Map<String, String> dimension = new HashMap<>(1);
         vms.forEach(vm -> {
             dimension.put("instanceId", vm.getInstanceUUID());
-            //监控指标
-            Arrays.stream(AliyunPerfMetricConstants.CloudServerPerfMetricEnum.values()).sorted().collect(Collectors.toList()).forEach(perfMetric -> {
-                describeMetricListRequest.setDimensions(JsonUtil.toJSONString(Arrays.asList(dimension)));
-                describeMetricListRequest.setMetricName(perfMetric.getMetricName());
-                try {
-                    //查询监控指标数据
-                    DescribeMetricListResponse response = cmsClient.describeMetricListWithOptions(describeMetricListRequest, new RuntimeOptions());
-                    if (StringUtils.equalsIgnoreCase(response.getBody().getCode(), "200") && !StringUtils.isBlank(response.getBody().getDatapoints())) {
-                        ArrayNode jsonArray = JsonUtil.parseArray(response.getBody().getDatapoints());
-                        jsonArray.forEach(v -> {
-                            F2CPerfMetricMonitorData f2CEntityPerfMetric = AliyunMappingUtil.toF2CPerfMetricMonitorData(v);
-                            f2CEntityPerfMetric.setDevice(v.get("device") == null ? null : v.get("device").toString());
-                            f2CEntityPerfMetric.setEntityType(F2CEntityType.VIRTUAL_MACHINE.name());
-                            f2CEntityPerfMetric.setMetricName(perfMetric.name());
-                            f2CEntityPerfMetric.setPeriod(getMetricsRequest.getPeriod());
-                            f2CEntityPerfMetric.setInstanceId(vm.getInstanceUUID());
-                            f2CEntityPerfMetric.setUnit(perfMetric.getUnit());
-                            result.add(f2CEntityPerfMetric);
-                        });
-                    }
-                } catch (Exception e) {
-                    e.printStackTrace();
-                }
-            });
-
+            describeMetricListRequest.setDimensions(JsonUtil.toJSONString(List.of(dimension)));
+            getVmMonitoringData(getMetricsRequest, result, describeMetricListRequest, cmsClient, vm);
         });
         return result;
     }
+
+    /**
+     * 通过监控指标查询云主机监控数据
+     *
+     * @param getMetricsRequest         查询监控的所有参数
+     * @param result                    结果
+     * @param describeMetricListRequest 查询监控API的参数
+     * @param cmsClient                 请求客户端
+     * @param vm                        要查询监控数据的云主机
+     */
+    private static void getVmMonitoringData(GetMetricsRequest getMetricsRequest, List<F2CPerfMetricMonitorData> result, DescribeMetricListRequest describeMetricListRequest, com.aliyun.cms20190101.Client cmsClient, F2CVirtualMachine vm) {
+        Arrays.stream(AliyunPerfMetricConstants.CloudServerPerfMetricEnum.values()).sorted().toList().forEach(perfMetric -> {
+            // 判断使用基础指标还是Agent指标
+            describeMetricListRequest.setMetricName(vm.isAgentRunning() ? perfMetric.getAgentMetricName() : perfMetric.getBaseMetricName());
+            try {
+                //查询监控指标数据
+                DescribeMetricListResponse response = cmsClient.describeMetricListWithOptions(describeMetricListRequest, new RuntimeOptions());
+                if (StringUtils.equalsIgnoreCase(response.getBody().getCode(), "200") && !StringUtils.isBlank(response.getBody().getDatapoints())) {
+                    ArrayNode monitoringData = JsonUtil.parseArray(response.getBody().getDatapoints());
+                    monitoringData.forEach(v -> {
+                        F2CPerfMetricMonitorData f2CEntityPerfMetric = AliyunMappingUtil.toF2CPerfMetricMonitorData(v);
+                        // 磁盘使用率时，该字段device不为空
+                        f2CEntityPerfMetric.setDevice(v.get("device") == null ? null : v.get("device").toString());
+                        f2CEntityPerfMetric.setEntityType(F2CEntityType.VIRTUAL_MACHINE.name());
+                        f2CEntityPerfMetric.setMetricName(perfMetric.name());
+                        f2CEntityPerfMetric.setPeriod(getMetricsRequest.getPeriod());
+                        f2CEntityPerfMetric.setInstanceId(vm.getInstanceUUID());
+                        f2CEntityPerfMetric.setUnit(perfMetric.getUnit());
+                        result.add(f2CEntityPerfMetric);
+                    });
+                }
+            } catch (Exception e) {
+                LogUtil.error("同步 阿里云 云主机 " + vm.getName() + " 监控指标 " + perfMetric.getDescription() + " 失败:" + e.getMessage());
+            }
+        });
+    }
+
+    /**
+     * 获取区域所有云主机
+     */
+    private static List<F2CVirtualMachine> getRegionAllVms(String credential, String regionId) {
+        ListVirtualMachineRequest listVirtualMachineRequest = new ListVirtualMachineRequest();
+        listVirtualMachineRequest.setCredential(credential);
+        listVirtualMachineRequest.setRegion(regionId);
+        List<F2CVirtualMachine> vms = listVirtualMachine(listVirtualMachineRequest);
+        if (CollectionUtils.isEmpty(vms)) {
+            return new ArrayList<>();
+        } else {
+            return setVmsAgentStatus(vms, credential, regionId);
+        }
+    }
+
+    /**
+     * 云主机设置agent状态
+     */
+    private static List<F2CVirtualMachine> setVmsAgentStatus(List<F2CVirtualMachine> vms, String credential, String regionId) {
+        AliyunVmCredential aliyunVmCredential = JsonUtil.parseObject(credential, AliyunVmCredential.class);
+        com.aliyun.cms20190101.Client cmsClient = aliyunVmCredential.getCmsClientByRegion(regionId);
+        List<String> vmUuids = vms.stream().map(F2CVirtualMachine::getInstanceUUID).toList();
+        DescribeMonitoringAgentStatusesRequest agentStatusesRequest = new DescribeMonitoringAgentStatusesRequest().setInstanceIds(Joiner.on(",").join(vmUuids));
+        com.aliyun.teautil.models.RuntimeOptions runtime = new com.aliyun.teautil.models.RuntimeOptions();
+        try {
+            DescribeMonitoringAgentStatusesResponse response = cmsClient.describeMonitoringAgentStatusesWithOptions(agentStatusesRequest, runtime);
+            List<DescribeMonitoringAgentStatusesResponseBody.DescribeMonitoringAgentStatusesResponseBodyNodeStatusListNodeStatus> nodeStatusList = response.getBody().getNodeStatusList().getNodeStatus();
+            Map<String, DescribeMonitoringAgentStatusesResponseBody.DescribeMonitoringAgentStatusesResponseBodyNodeStatusListNodeStatus> instanceAgentStatus =
+                    nodeStatusList.stream().collect(Collectors.toMap(DescribeMonitoringAgentStatusesResponseBody.DescribeMonitoringAgentStatusesResponseBodyNodeStatusListNodeStatus::getInstanceId, o -> o));
+            for (F2CVirtualMachine virtualMachine : vms) {
+                if (instanceAgentStatus.containsKey(virtualMachine.getInstanceUUID())) {
+                    virtualMachine.setAgentRunning(StringUtils.equalsIgnoreCase("running", instanceAgentStatus.get(virtualMachine.getInstanceUUID()).getStatus()));
+                }
+            }
+        } catch (Exception e) {
+            LogUtil.error("Cloud server query monitoring plugin status failed:" + e.getMessage());
+        }
+        return vms;
+    }
+
 
     /**
      * 扩容磁盘
@@ -1832,4 +1809,5 @@ public class AliyunSyncCloudApi {
             throw new RuntimeException("GetVmF2CDisks Error!" + e.getMessage(), e);
         }
     }
+
 }

--- a/services/vm-service/backend/src/main/java/com/fit2cloud/provider/impl/aliyun/constants/AliyunPerfMetricConstants.java
+++ b/services/vm-service/backend/src/main/java/com/fit2cloud/provider/impl/aliyun/constants/AliyunPerfMetricConstants.java
@@ -9,27 +9,72 @@ package com.fit2cloud.provider.impl.aliyun.constants;
 public class AliyunPerfMetricConstants {
 
     /**
-     * 云主机性能指标枚举
+     * 云主机性能监控指标指标
+     * 监控数据粒度60秒
      */
     public enum CloudServerPerfMetricEnum {
-        CPU_USED_UTILIZATION("CPUUtilization", "CPU使用率", "%"),
-        MEMORY_USED_UTILIZATION("memory_usedutilization", "内存使用率", "%"),
-        DISK_READ_BPS("DiskReadBPS", "所有磁盘读取BPS", "Byte/s"),
-        DISK_WRITE_BPS("DiskWriteBPS", "所有磁盘写入BPS", "Byte/s"),
-        DISK_READ_IOPS("DiskReadIOPS", "所有磁盘每秒读取次数", "Count/Second"),
-        DISK_WRITE_IOPS("DiskWriteIOPS", "所有磁盘每秒写入次数", "Count/Second"),
-        INTERNET_IN_RATE("VPC_PublicIP_InternetInRate", "公网流入带宽", "bit/s"),
-        INTERNET_OUT_RATE("VPC_PublicIP_InternetOutRate", "公网流出带宽", "bit/s"),
-        INTRANET_IN_RATE("IntranetInRate", "内网流入带宽", "bit/s"),
-        INTRANET_OUT_RATE("IntranetOutRate", "内网流出带宽", "bit/s"),
-        DISK_USED_UTILIZATION("diskusage_utilization", "磁盘使用率", "%"),
+        /**
+         * CPU使用率
+         */
+        CPU_USED_UTILIZATION("CPUUtilization", "cpu_total", "CPU使用率", "%"),
+        /**
+         * 内存使用率
+         */
+        MEMORY_USED_UTILIZATION("", "memory_usedutilization", "内存使用率", "%"),
+        /**
+         * 磁盘读取BPS
+         * 如果是基础指标，表示针对所有磁盘，否则单个磁盘
+         */
+        DISK_READ_BPS("DiskReadBPS", "disk_readbytes", "磁盘读取BPS", "bytes/s"),
+        /**
+         * 磁盘写入BPS
+         * 如果是基础指标，表示针对所有磁盘，否则单个磁盘
+         */
+        DISK_WRITE_BPS("DiskWriteBPS", "disk_writebytes", "磁盘写入BPS", "bytes/s"),
+        /**
+         * 磁盘每秒读取次数
+         * 如果是基础指标，表示针对所有磁盘，否则单个磁盘
+         */
+        DISK_READ_IOPS("DiskReadIOPS", "disk_readiops", "磁盘每秒读取次数", "Count/Second"),
+        /**
+         * 磁盘每秒写入次数
+         * 如果是基础指标，表示针对所有磁盘，否则单个磁盘
+         */
+        DISK_WRITE_IOPS("DiskWriteIOPS", "disk_writeiops", "磁盘每秒写入次数", "Count/Second"),
+        /**
+         * 公网流入带宽
+         * 不区分基础跟Agent，因为Agent没找到对应的指标,直接使用基础的指标
+         */
+        INTERNET_IN_RATE("VPC_PublicIP_InternetInRate", "VPC_PublicIP_InternetInRate", "公网流入带宽", "bit/s"),
+        /**
+         * 公网流出带宽
+         * 不区分基础跟Agent，因为Agent没找到对应的指标,直接使用基础的指标
+         */
+        INTERNET_OUT_RATE("VPC_PublicIP_InternetOutRate", "VPC_PublicIP_InternetOutRate", "公网流出带宽", "bit/s"),
+        /**
+         * 内网流入带宽
+         * 不区分基础跟Agent，因为Agent没找到对应的指标,直接使用基础的指标
+         */
+        INTRANET_IN_RATE("IntranetInRate", "IntranetInRate", "内网流入带宽", "bit/s"),
+        /**
+         * 内网流出带宽
+         * 不区分基础跟Agent，因为Agent没找到对应的指标,直接使用基础的指标
+         */
+        INTRANET_OUT_RATE("IntranetOutRate", "IntranetOutRate", "内网流出带宽", "bit/s"),
+        /**
+         * 磁盘使用率
+         */
+        DISK_USED_UTILIZATION("", "diskusage_utilization", "磁盘使用率", "%"),
         ;
 
         /**
-         * 名称
+         * 基础监控指标名称
          */
-        private final String metricName;
-
+        private final String baseMetricName;
+        /**
+         * Agent监控指标名称
+         */
+        private final String agentMetricName;
         /**
          * 描述
          */
@@ -39,57 +84,19 @@ public class AliyunPerfMetricConstants {
          */
         private final String unit;
 
-        CloudServerPerfMetricEnum(String metricName, String description, String unit) {
-            this.metricName = metricName;
+        CloudServerPerfMetricEnum(String baseMetricName, String agentMetricName, String description, String unit) {
+            this.baseMetricName = baseMetricName;
+            this.agentMetricName = agentMetricName;
             this.description = description;
             this.unit = unit;
         }
 
-        public String getMetricName() {
-            return metricName;
+        public String getBaseMetricName() {
+            return baseMetricName;
         }
 
-        public String getDescription() {
-            return description;
-        }
-
-        public String getUnit() {
-            return unit;
-        }
-
-    }
-
-    /**
-     * 磁盘枚举
-     */
-    public enum CloudDiskPerfMetricEnum {
-        DISK_READ_BPS("DiskReadBytes", "磁盘读取BPS", "Bytes/s"),
-        DISK_WRITE_BPS("DiskWriteBytes", "磁盘写入BPS", "Bytes/s"),
-        DISK_READ_IOPS("DiskIOPSRead", "磁盘每秒读取次数", "Count/Second"),
-        DISK_WRITE_IOPS("DiskIOPSWrite", "磁盘每秒写入次数", "Count/Second"),
-        ;
-        /**
-         * 名称
-         */
-        private final String metricName;
-
-        /**
-         * 描述
-         */
-        private final String description;
-        /**
-         * 单位
-         */
-        private final String unit;
-
-        CloudDiskPerfMetricEnum(String metricName, String description, String unit) {
-            this.metricName = metricName;
-            this.description = description;
-            this.unit = unit;
-        }
-
-        public String getMetricName() {
-            return metricName;
+        public String getAgentMetricName() {
+            return agentMetricName;
         }
 
         public String getDescription() {

--- a/services/vm-service/backend/src/main/java/com/fit2cloud/provider/impl/huawei/HuaweiCloudProvider.java
+++ b/services/vm-service/backend/src/main/java/com/fit2cloud/provider/impl/huawei/HuaweiCloudProvider.java
@@ -156,7 +156,7 @@ public class HuaweiCloudProvider extends AbstractCloudProvider<HuaweiVmCredentia
 
     @Override
     public List<F2CPerfMetricMonitorData> getF2CDiskPerfMetricMonitorData(String req) {
-        return HuaweiSyncCloudApi.getF2CDiskPerfMetricList(JsonUtil.parseObject(req, GetMetricsRequest.class));
+        return new ArrayList<>();
     }
 
     public List<NovaAvailabilityZoneDTO> getAvailabilityZone(String req) {

--- a/services/vm-service/backend/src/main/java/com/fit2cloud/provider/impl/huawei/constants/HuaweiPerfMetricConstants.java
+++ b/services/vm-service/backend/src/main/java/com/fit2cloud/provider/impl/huawei/constants/HuaweiPerfMetricConstants.java
@@ -8,25 +8,70 @@ public class HuaweiPerfMetricConstants {
 
     /**
      * 云主机性能指标枚举
+     * 监控数据粒度300秒
+     * 网络统一为基础指标，Agnet没有
+     * 华为云无法判断云主机agent状态
+     * 处理方式：查询Agent指标无数据，转查询基础指标监控
+     * 除了CPU,内存，磁盘与网络都是基础指标的数据，因为API无法获取
+     * 官网有指标，但是无法读取数据，缺少参数（mount_pint）
      */
     public enum CloudServerPerfMetricEnum {
-        CPU_USED_UTILIZATION("cpu_util", "CPU使用率", "%"),
-        MEMORY_USED_UTILIZATION("mem_usedPercent", "内存使用率", "%"),
-        DISK_READ_BPS("disk_read_bytes_rate", "所有磁盘读取BPS", "Byte/s"),
-        DISK_WRITE_BPS("disk_write_bytes_rate", "所有磁盘写入BPS", "Byte/s"),
-        DISK_READ_IOPS("disk_read_requests_rate", "所有磁盘每秒读取次数", "Count/Second"),
-        DISK_WRITE_IOPS("disk_write_requests_rate", "所有磁盘每秒写入次数", "Count/Second"),
-        INTERNET_IN_RATE("network_incoming_bytes_aggregate_rate", "公网流入带宽", "Byte/s"),
-        INTERNET_OUT_RATE("network_outgoing_bytes_aggregate_rate", "公网流出带宽", "Byte/s"),
-        INTRANET_IN_RATE("network_vm_bandwidth_in", "内网流入带宽", "KB/s"),
-        INTRANET_OUT_RATE("network_vm_bandwidth_out", "内网流出带宽", "KB/s"),
-        DISK_USED_UTILIZATION("disk_util_inband", "磁盘使用率", "%"),
+        /**
+         * CPU使用率
+         */
+        CPU_USED_UTILIZATION("cpu_util", "cpu_usage", "CPU使用率", "%"),
+        /**
+         * 内存使用率
+         */
+        MEMORY_USED_UTILIZATION("mem_util", "mem_usedPercent", "内存使用率", "%"),
+        /**
+         * 所有磁盘读取BPS
+         */
+        DISK_READ_BPS("disk_read_bytes_rate", "mountPointPrefix_disk_agt_read_bytes_rate", "所有磁盘读取BPS", "byte/s"),
+        /**
+         * 所有磁盘写入BPS
+         */
+        DISK_WRITE_BPS("disk_write_bytes_rate", "mountPointPrefix_disk_agt_write_bytes_rate", "所有磁盘写入BPS", "byte/s"),
+        /**
+         * 所有磁盘每秒读取次数
+         */
+        DISK_READ_IOPS("disk_read_requests_rate", "mountPointPrefix_disk_agt_read_requests_rate", "所有磁盘每秒读取次数", "Count/Second"),
+        /**
+         * 所有磁盘每秒写入次数
+         */
+        DISK_WRITE_IOPS("disk_write_requests_rate", "mountPointPrefix_disk_agt_write_requests_rate", "所有磁盘每秒写入次数", "Count/Second"),
+        /**
+         * 公网流入带宽
+         */
+        INTERNET_IN_RATE("network_incoming_bytes_aggregate_rate", "network_incoming_bytes_aggregate_rate", "公网流入带宽", "Byte/s"),
+        /**
+         * 公网流出带宽
+         */
+        INTERNET_OUT_RATE("network_outgoing_bytes_aggregate_rate", "network_outgoing_bytes_aggregate_rate", "公网流出带宽", "Byte/s"),
+        /**
+         * 内网流入带宽
+         */
+        INTRANET_IN_RATE("network_vm_bandwidth_in", "network_vm_bandwidth_in", "内网流入带宽", "KB/s"),
+        /**
+         * 内网流出带宽
+         */
+        INTRANET_OUT_RATE("network_vm_bandwidth_out", "network_vm_bandwidth_out", "内网流出带宽", "KB/s"),
+//        /**
+//         * 磁盘使用率
+//         * 暂无法使用该指标
+//         */
+//        DISK_USED_UTILIZATION("disk_util_inband", "mountPointPrefix_disk_usedPercent","磁盘使用率", "%"),
         ;
 
         /**
-         * 名称
+         * 基础监控指标名称
          */
-        private final String metricName;
+        private final String baseMetricName;
+
+        /**
+         * Agent监控指标名称
+         */
+        private final String agentMetricName;
 
         /**
          * 描述
@@ -37,14 +82,19 @@ public class HuaweiPerfMetricConstants {
          */
         private final String unit;
 
-        CloudServerPerfMetricEnum(String metricName, String description, String unit) {
-            this.metricName = metricName;
+        CloudServerPerfMetricEnum(String baseMetricName, String agentMetricName, String description, String unit) {
+            this.baseMetricName = baseMetricName;
+            this.agentMetricName = agentMetricName;
             this.description = description;
             this.unit = unit;
         }
 
-        public String getMetricName() {
-            return metricName;
+        public String getBaseMetricName() {
+            return baseMetricName;
+        }
+
+        public String getAgentMetricName() {
+            return agentMetricName;
         }
 
         public String getDescription() {
@@ -57,47 +107,4 @@ public class HuaweiPerfMetricConstants {
 
     }
 
-    /**
-     * 磁盘的无法获取
-     * 磁盘枚举
-     */
-    public enum CloudDiskPerfMetricEnum {
-        DISK_READ_BPS("DiskReadBytes", "磁盘读取BPS", "Bytes/s"),
-        DISK_WRITE_BPS("DiskWriteBytes", "磁盘写入BPS", "Bytes/s"),
-        DISK_READ_IOPS("DiskIOPSRead", "磁盘每秒读取次数", "Count/Second"),
-        DISK_WRITE_IOPS("DiskIOPSWrite", "磁盘每秒写入次数", "Count/Second"),
-        ;
-        /**
-         * 名称
-         */
-        private final String metricName;
-
-        /**
-         * 描述
-         */
-        private final String description;
-        /**
-         * 单位
-         */
-        private final String unit;
-
-        CloudDiskPerfMetricEnum(String metricName, String description, String unit) {
-            this.metricName = metricName;
-            this.description = description;
-            this.unit = unit;
-        }
-
-        public String getMetricName() {
-            return metricName;
-        }
-
-        public String getDescription() {
-            return description;
-        }
-
-        public String getUnit() {
-            return unit;
-        }
-
-    }
 }

--- a/services/vm-service/backend/src/main/java/com/fit2cloud/provider/impl/tencent/TencentCloudProvider.java
+++ b/services/vm-service/backend/src/main/java/com/fit2cloud/provider/impl/tencent/TencentCloudProvider.java
@@ -364,7 +364,7 @@ public class TencentCloudProvider extends AbstractCloudProvider<TencentCredentia
 
     @Override
     public List<F2CPerfMetricMonitorData> getF2CDiskPerfMetricMonitorData(String req) {
-        return TencentSyncCloudApi.getF2CDiskPerfMetricList(JsonUtil.parseObject(req, GetMetricsRequest.class));
+        return new ArrayList<>();
     }
 
     @Override

--- a/services/vm-service/backend/src/main/java/com/fit2cloud/provider/impl/tencent/api/TencentSyncCloudApi.java
+++ b/services/vm-service/backend/src/main/java/com/fit2cloud/provider/impl/tencent/api/TencentSyncCloudApi.java
@@ -1143,7 +1143,9 @@ public class TencentSyncCloudApi {
         }
         List<F2CPerfMetricMonitorData> result = new ArrayList<>();
         //设置时间，根据syncTimeStampStr,默认一个小时
-        getMetricsRequest.setStartTime(String.valueOf(DateUtil.beforeOneHourToTimestamp(Long.valueOf(getMetricsRequest.getSyncTimeStampStr()))));
+        Long startTime = DateUtil.beforeOneHourToTimestamp(Long.valueOf(getMetricsRequest.getSyncTimeStampStr()));
+        //多获取过去30分钟的数据，防止同步线程时间不固定，导致数据不全的问题
+        getMetricsRequest.setStartTime(String.valueOf(startTime-1800000L));
         getMetricsRequest.setEndTime(getMetricsRequest.getSyncTimeStampStr());
         try {
             getMetricsRequest.setRegionId(getMetricsRequest.getRegionId());
@@ -1155,33 +1157,6 @@ public class TencentSyncCloudApi {
             result.addAll(getVmDiskPerfMetric(monitorClient, request, getMetricsRequest));
         } catch (Exception e) {
             throw new SkipPageException(100021, "获取监控数据失败-" + getMetricsRequest.getRegionId() + "-" + e.getMessage());
-        }
-        return result;
-    }
-
-    /**
-     * 暂时不实现
-     *
-     * @param getMetricsRequest
-     * @return
-     */
-    public static List<F2CPerfMetricMonitorData> getF2CDiskPerfMetricList(GetMetricsRequest getMetricsRequest) {
-        if (StringUtils.isEmpty(getMetricsRequest.getRegionId())) {
-            throw new Fit2cloudException(10002, "区域为必填参数");
-        }
-        List<F2CPerfMetricMonitorData> result = new ArrayList<>();
-        //设置时间，根据syncTimeStampStr,默认一个小时
-        getMetricsRequest.setStartTime(String.valueOf(DateUtil.beforeOneHourToTimestamp(Long.valueOf(getMetricsRequest.getSyncTimeStampStr()))));
-        getMetricsRequest.setEndTime(getMetricsRequest.getSyncTimeStampStr());
-        try {
-            getMetricsRequest.setRegionId(getMetricsRequest.getRegionId());
-            TencentVmCredential credential = JsonUtil.parseObject(getMetricsRequest.getCredential(), TencentVmCredential.class);
-            GetMonitorDataRequest request = getShowMetricDataRequest(getMetricsRequest);
-            MonitorClient monitorClient = credential.getMonitorClient(getMetricsRequest.getRegionId());
-            //result.addAll(getDiskPerfMetric(monitorClient, request, getMetricsRequest));
-        } catch (Exception e) {
-            SkipPageException.throwSkipPageException(e);
-            throw new Fit2cloudException(100021, "获取监控数据失败-" + getMetricsRequest.getRegionId() + "-" + e.getMessage());
         }
         return result;
     }


### PR DESCRIPTION
fix(vm-service sdk): 公有云云主机查询监控数据逻辑调整，优先查询Agent监控数据  所有公有云在查询监控数据时，开始时间推到过去一个半小时，防止同步时间不固定导致数据遗漏问题。 1.阿里云，判断监控Agent是否运行，运行中查询Agent的指标，否则查询基础指标。 2.华为云，无法判断Agent状态，处理方式，先查询Agent指标，无数据时，查询基础指标。 3.腾讯云，无Agent指标 