### PR TITLE
fix: 申请VMware的windows主机会被设置密码为password

### DIFF
--- a/services/vm-service/backend/src/main/java/com/fit2cloud/provider/impl/vsphere/util/VsphereVmClient.java
+++ b/services/vm-service/backend/src/main/java/com/fit2cloud/provider/impl/vsphere/util/VsphereVmClient.java
@@ -1196,7 +1196,7 @@ public class VsphereVmClient extends VsphereClient {
         //todo windows 设置密码
         customizationPassword.setValue("password");
 
-        cgu.setPassword(customizationPassword);
+        //cgu.setPassword(customizationPassword);
         sysprep.setGuiUnattended(cgu);
         sysprep.setIdentification(ci);
         sysprep.setUserData(customizationUserData);


### PR DESCRIPTION
fix: 申请VMware的windows主机会被设置密码为password 