### PR TITLE
fix(vm-service,sdk): 创建云主机BUG修复

### DIFF
--- a/framework/sdk/backend/src/main/java/com/fit2cloud/common/form/constants/InputType.java
+++ b/framework/sdk/backend/src/main/java/com/fit2cloud/common/form/constants/InputType.java
@@ -87,6 +87,7 @@ public enum InputType {
     HuaweiDiskConfigForm(com.fit2cloud.common.form.vo.huawei.DiskConfigForm.class),
     HuaweiNetworkConfigForm(com.fit2cloud.common.form.vo.huawei.NetworkConfigForm.class),
     HuaweiNameConfigForm(com.fit2cloud.common.form.vo.huawei.NameConfigForm.class),
+    HuaweiPasswordInfoForm(com.fit2cloud.common.form.vo.huawei.HuaweiPasswordInfoForm.class),
 
     VsphereClusterForm(com.fit2cloud.common.form.vo.vsphere.ClusterForm.class),
     VsphereDiskConfigForm(com.fit2cloud.common.form.vo.vsphere.DiskConfigForm.class),

--- a/framework/sdk/backend/src/main/java/com/fit2cloud/common/form/vo/huawei/HuaweiPasswordInfoForm.java
+++ b/framework/sdk/backend/src/main/java/com/fit2cloud/common/form/vo/huawei/HuaweiPasswordInfoForm.java
@@ -1,0 +1,7 @@
+package com.fit2cloud.common.form.vo.huawei;
+
+import com.fit2cloud.common.form.vo.Form;
+
+
+public class HuaweiPasswordInfoForm extends Form {
+}

--- a/framework/sdk/frontend/commons/components/ce-form/items/RegexInput.vue
+++ b/framework/sdk/frontend/commons/components/ce-form/items/RegexInput.vue
@@ -1,31 +1,58 @@
-<template>
-  <ce-regex-tooltip
-    :description="props.formItem.description"
-    :model-value="_modelValue"
-    :rules="rules"
-  >
-    <el-input
-      ref="regexInputRef"
-      v-bind="$attrs"
-      :show-password="props.formItem.encrypted"
-      :placeholder="props.placeholder ? props.placeholder : ''"
-      v-model="_modelValue"
-    />
-  </ce-regex-tooltip>
+<template v-loading="_loading">
+  <div style="width: 100%">
+    <template v-if="!confirm">
+      <el-form-item :rules="rules" :prop="props.field">
+        <ce-regex-tooltip
+          :description="props.formItem.description"
+          :model-value="_data"
+          :rules="rules"
+        >
+          <el-input
+            v-bind="$attrs"
+            :show-password="props.formItem.encrypted"
+            v-model="_data"
+          />
+        </ce-regex-tooltip>
+      </el-form-item>
+    </template>
+    <template v-else>
+      <div class="detail-box">
+        <el-descriptions :column="3" direction="vertical">
+          <el-descriptions-item width="33.33%" />
+        </el-descriptions>
+      </div>
+    </template>
+  </div>
 </template>
-
 <script setup lang="ts">
 import { computed, ref } from "vue";
+import { type FormInstance } from "element-plus";
 import type { FormView } from "@commons/components/ce-form/type";
 const props = defineProps<{
   modelValue?: string;
-  placeholder?: string;
+  allData?: any;
+  allFormViewData?: Array<FormView>;
+  field: string;
+  otherParams: any;
   formItem: FormView;
-  setDefaultValue?: boolean;
+  confirm?: boolean;
 }>();
-const showTooltip = ref<boolean>(false);
+
 const emit = defineEmits(["update:modelValue", "change"]);
-const _modelValue = computed({
+
+// 校验实例对象
+const ruleFormRef = ref<FormInstance>();
+const _loading = ref<boolean>(false);
+const defaultRules = ref<Array<any>>([{ regex: /\S/, message: "不能为空" }]);
+const rules = computed<Array<any>>(() => {
+  if (props.formItem.propsInfo?.rules) {
+    return props.formItem.propsInfo?.rules;
+  } else {
+    return defaultRules;
+  }
+});
+
+const _data = computed({
   get() {
     return props.modelValue;
   },
@@ -33,35 +60,38 @@ const _modelValue = computed({
     emit("update:modelValue", value);
   },
 });
-const defaultRules = ref<Array<any>>([{ regex: /\S/, message: "不能为空" }]);
-const rules = computed<Array<any>>(() => {
-  if (props.formItem.regexList) {
-    return props.formItem.regexList;
-  } else {
-    return defaultRules;
-  }
-});
-const valid = computed(() => {
-  return rules?.value?.every((regex) => {
-    return new RegExp(regex.regex).test(_modelValue.value as string);
-  });
-});
-const regexInputRef = ref<any>();
-
-function validate(): Promise<boolean> {
-  if (!valid.value) {
-    regexInputRef.value.focus();
-    showTooltip.value = true;
-    return new Promise((resolve, reject) => {
-      return reject(props.formItem.label + "输入有误！");
-    });
-  }
-  return regexInputRef.value.pending;
-}
-
-defineExpose({
-  validate,
-});
 </script>
+<style lang="scss" scoped>
+.box-content {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  align-items: center;
+  padding: 18px;
+  background-color: #f7f9fc;
+  border-radius: 4px;
+  .el-form-item {
+    margin-bottom: 0;
+    margin-right: 0;
+    padding: 0px 2px 0px 8px;
+    width: 100%;
+    .el-form-item__content .custom-popover {
+      width: 100%;
+    }
+  }
 
-<style lang="scss" scoped></style>
+  .delete-icon {
+    cursor: pointer;
+    margin-left: 8px;
+  }
+}
+.add-button {
+  margin: 10px;
+}
+.detail-box {
+  margin-top: 8px;
+  :deep(.el-descriptions__header) {
+    margin-bottom: 0 !important;
+  }
+}
+</style>

--- a/framework/sdk/frontend/commons/components/ce-form/items/TableCheckbox.vue
+++ b/framework/sdk/frontend/commons/components/ce-form/items/TableCheckbox.vue
@@ -3,11 +3,11 @@
     <div class="header">
       <div class="title">{{ formItem.propsInfo.title }}</div>
       <el-input
-          v-model="filterText"
-          :validate-event="false"
-          placeholder="请输入关键字搜索"
-          class="input-with-select"
-          style="--el-color-danger: #c0c4cc"
+        v-model="filterText"
+        :validate-event="false"
+        placeholder="请输入关键字搜索"
+        class="input-with-select"
+        style="--el-color-danger: #c0c4cc"
       >
         <template #prepend>
           <el-button :icon="Search" />

--- a/framework/sdk/frontend/commons/components/ce-form/items/aliyun/AliyunDiskConfigForm.vue
+++ b/framework/sdk/frontend/commons/components/ce-form/items/aliyun/AliyunDiskConfigForm.vue
@@ -48,7 +48,6 @@
               :min="minSize(defaultDisks[index], index)"
               :max="maxSize(defaultDisks[index], index)"
               :step="10"
-              :readonly="index === 0 ? obj.readonly : false"
               required
               style="width: 200px; margin-left: 8px"
             >

--- a/framework/sdk/frontend/commons/components/ce-form/items/aliyun/AliyunServerInfoForm.vue
+++ b/framework/sdk/frontend/commons/components/ce-form/items/aliyun/AliyunServerInfoForm.vue
@@ -7,7 +7,7 @@
       label-position="top"
       style="width: 100%"
       :model="_data"
-      :show-message="false"
+      :show-message="true"
       :size="''"
       :scroll-to-error="true"
     >
@@ -89,8 +89,9 @@ const _loading = ref<boolean>(false);
 
 const nameRules = [
   {
-    message:
+    regexMessage:
       "2～128个字符，以大小写字母或中文开头，可包含数字、点号（.）、下划线（_）、半角冒号（:）或连字符（-）",
+    message: "云主机名称不符合规则要求",
     trigger: "blur",
     pattern:
       "(^[A-Za-z\u4e00-\u9fa5]{1}[A-Za-z0-9_\\-\\.\\:\u4e00-\u9fa5]{1,128}$)|(^\\s*$)",
@@ -101,8 +102,9 @@ const nameRules = [
 ];
 const hostNameRules = [
   {
-    message:
-      "2～64个字符,只能包含小写字母、大写字母、数字、点或横线.不能出现连续的特殊字符，不能以特殊字符开头结尾。",
+    regexMessage:
+      "2～64个字符,只能包含小写字母、大写字母、数字、点或横线且是合法的FQDN.不能出现连续的特殊字符，不能以特殊字符开头结尾。",
+    message: "Hostname不符合规则要求",
     trigger: "blur",
     pattern: "^([0-9a-zA-Z]+[\\.\\-])*[0-9a-zA-Z]{2,64}$",
     regex: "^([0-9a-zA-Z]+[\\.\\-])*[0-9a-zA-Z]{2,64}$",

--- a/framework/sdk/frontend/commons/components/ce-form/items/huawei/HuaweiDiskConfigForm.vue
+++ b/framework/sdk/frontend/commons/components/ce-form/items/huawei/HuaweiDiskConfigForm.vue
@@ -27,7 +27,6 @@
               :min="index === 0 ? imageDiskMinSize : 10"
               :max="index === 0 ? 1024 : 32768"
               :step="10"
-              :readonly="index === 0 ? obj.readonly : false"
               required
               style="width: 200px; margin-left: 8px"
             >
@@ -98,6 +97,21 @@ const diskTypeOptions = computed<DiskTypeOption[]>(() => {
   }
   return [];
 });
+/**
+ * 监听盘类型变化
+ * 如果已选类型不在盘类型中默认选第一个磁盘类型
+ */
+watch(
+  () => diskTypeOptions.value,
+  () => {
+    const first = _.head(diskTypeOptions.value!);
+    _.forEach(props.modelValue, (item) => {
+      if (!_.includes(diskTypeOptions.value, item.id)) {
+        item.diskType = _.get(first, "id");
+      }
+    });
+  }
+);
 /**
  * 系统盘最小值
  */

--- a/framework/sdk/frontend/commons/components/ce-form/items/huawei/HuaweiNameConfigForm.vue
+++ b/framework/sdk/frontend/commons/components/ce-form/items/huawei/HuaweiNameConfigForm.vue
@@ -1,63 +1,67 @@
 <template v-loading="_loading">
-  <template v-if="!confirm">
-    <el-form
-      ref="ruleFormRef"
-      label-width="130px"
-      label-suffix=":"
-      label-position="top"
-      style="width: 100%"
-      :model="_data"
-      :show-message="false"
-      :size="''"
-      :scroll-to-error="true"
-    >
-      <template v-for="(item, index) in _data" :key="index">
-        <div class="box-title">
-          {{ index === 0 ? "主机" : "主机 " + index }}
-        </div>
-        <div class="box-content">
-          <el-form-item :rules="nameRules" :prop="'[' + index + '].name'">
-            <ce-regex-tooltip
-              :ref="'nameInputRef' + index"
-              :description="'主机名称必须同时符合以下规则'"
-              :model-value="item.name"
-              :rules="nameRules"
-            >
-              <el-input placeholder="请输入云主机名称" v-model="item.name" />
-            </ce-regex-tooltip>
-          </el-form-item>
-          <el-form-item
-            :rules="hostNameRules"
-            :prop="'[' + index + '].hostname'"
-          >
-            <tooltip
-              :ref="'hostNameInputRef' + index"
-              :description="'Hostname必须同时符合以下规则'"
-              :model-value="item.hostname"
+  <div style="width: 100%">
+    <template v-if="!confirm">
+      <el-form
+        ref="ruleFormRef"
+        label-suffix=":"
+        label-position="left"
+        style="margin-bottom: 18px"
+        :model="_data"
+        :scroll-to-error="true"
+      >
+        <template v-for="(item, index) in _data" :key="index">
+          <div class="box-title">
+            {{ index === 0 ? "主机" : "主机 " + index }}
+          </div>
+          <div class="box-content">
+            <el-form-item :rules="nameRules" :prop="'[' + index + '].name'">
+              <ce-regex-tooltip
+                :ref="'nameInputRef' + index"
+                :description="'主机名称必须同时符合以下规则'"
+                :model-value="item.name"
+                :rules="nameRules"
+                :width="'50%'"
+              >
+                <el-input placeholder="请输入云主机名称" v-model="item.name" />
+              </ce-regex-tooltip>
+            </el-form-item>
+            <el-form-item
               :rules="hostNameRules"
+              :prop="'[' + index + '].hostname'"
             >
-              <el-input placeholder="请输入Hostname" v-model="item.hostname" />
-            </tooltip>
-          </el-form-item>
-        </div>
-      </template>
-    </el-form>
-  </template>
-  <template v-else>
-    <div class="detail-box">
-      <template v-for="(o, i) in modelValue" :key="i">
-        <el-descriptions :title="'主机' + (i + 1)">
-          <el-descriptions-item>
-            <detail-page
-              :content="getModelValueDetail(o)"
-              :item-width="'33.33%'"
-              :item-bottom="'28px'"
-            ></detail-page>
-          </el-descriptions-item>
-        </el-descriptions>
-      </template>
-    </div>
-  </template>
+              <tooltip
+                :ref="'hostNameInputRef' + index"
+                :description="'Hostname必须同时符合以下规则'"
+                :model-value="item.hostname"
+                :rules="hostNameRules"
+                :width="'50%'"
+              >
+                <el-input
+                  placeholder="请输入Hostname"
+                  v-model="item.hostname"
+                />
+              </tooltip>
+            </el-form-item>
+          </div>
+        </template>
+      </el-form>
+    </template>
+    <template v-else>
+      <div class="detail-box">
+        <template v-for="(o, i) in modelValue" :key="i">
+          <el-descriptions :title="'主机' + (i + 1)">
+            <el-descriptions-item>
+              <detail-page
+                :content="getModelValueDetail(o)"
+                :item-width="'33.33%'"
+                :item-bottom="'28px'"
+              ></detail-page>
+            </el-descriptions-item>
+          </el-descriptions>
+        </template>
+      </div>
+    </template>
+  </div>
 </template>
 <script setup lang="ts">
 import { computed, onMounted, ref, watch } from "vue";
@@ -89,18 +93,20 @@ const _loading = ref<boolean>(false);
 
 const nameRules = [
   {
-    message:
+    regexMessage:
       "只能由中文字符、英文字母、数字及“_”、“-”、“.”组成,且长度为[1-64]个字符。",
+    message: "云主机名称不符合规则要求",
     trigger: "blur",
-    pattern: "^[\u4E00-\u9FA5\\w.-]{1,64}$",
-    regex: "^[\u4E00-\u9FA5\\w.-]{1,64}$",
+    pattern: "^[\u4E00-\u9FFFa-zA-Z0-9_.-]{1,64}$",
+    regex: "^[\u4E00-\u9FFFa-zA-Z0-9_.-]{1,64}$",
     required: true,
   },
 ];
 const hostNameRules = [
   {
-    message:
+    regexMessage:
       "长度为 [1-64] 个字符,允许使用点号(.)分隔字符成多段,每段允许使用大小写字母、数字或连字符(-),但不能连续使用点号(.)或连字符(-),不能以点号(.)或连字符(-)开头或结尾,不能出现(.-)和(-.)。",
+    message: "Hostname不符合规则要求",
     trigger: "blur",
     pattern: "^(?!.*(?:\\.\\.|--))[a-zA-Z0-9]+(?:[-.][a-zA-Z0-9]+)*$",
     regex: "^(?!.*(?:\\.\\.|--))[a-zA-Z0-9]+(?:[-.][a-zA-Z0-9]+)*$",
@@ -117,15 +123,12 @@ const _data = computed({
   },
 });
 
-const activeTab = ref(0);
-
 /**
  * 监听数量变化，获取值
  */
 watch(
   () => props.allData.count,
   (count) => {
-    activeTab.value = count - 1;
     setServers(count);
   }
 );

--- a/framework/sdk/frontend/commons/components/ce-form/items/huawei/HuaweiPasswordInfoForm.vue
+++ b/framework/sdk/frontend/commons/components/ce-form/items/huawei/HuaweiPasswordInfoForm.vue
@@ -1,0 +1,134 @@
+<template v-loading="_loading">
+  <div style="width: 100%">
+    <template v-if="!confirm">
+      <el-form-item :rules="pwdRules" :prop="props.field">
+        <ce-regex-tooltip
+          :description="'登录密码必须同时符合以下规则'"
+          :model-value="_data"
+          :rules="pwdRules"
+        >
+          <el-input :show-password="true" v-bind="$attrs" v-model="_data" />
+        </ce-regex-tooltip>
+      </el-form-item>
+    </template>
+    <template v-else>
+      <div class="detail-box">
+        <el-descriptions :column="3" direction="vertical">
+          <el-descriptions-item width="33.33%" />
+        </el-descriptions>
+      </div>
+    </template>
+  </div>
+</template>
+<script setup lang="ts">
+import { computed, ref } from "vue";
+import { type FormInstance } from "element-plus";
+import type { FormView } from "@commons/components/ce-form/type";
+
+const props = defineProps<{
+  modelValue?: string;
+  allData?: any;
+  allFormViewData?: Array<FormView>;
+  field: string;
+  otherParams: any;
+  formItem: FormView;
+  confirm?: boolean;
+}>();
+
+const emit = defineEmits(["update:modelValue", "change"]);
+
+// 校验实例对象
+const ruleFormRef = ref<FormInstance>();
+const _loading = ref<boolean>(false);
+
+const regexByOs = computed(() => {
+  if (props.allData.os?.toLowerCase().indexOf("windows") > -1) {
+    return {
+      regexMessage:
+        "Windows系统密码不能包含用户名或用户名的逆序，不能包含用户名中超过两个连续字符的部分。",
+      message: "登录密码不符合规则要求",
+      trigger: "blur",
+      pattern:
+        "^(?!.*Adm)(?!.*dmi)(?!.*min)(?!.*ini)(?!.*nis)(?!.*ist)(?!.*str)(?!.*tra)(?!.*rat)(?!.*ato)(?!.*tor)(?!.*rotartsinimd[A|a]).*$",
+      regex:
+        "^(?!.*Adm)(?!.*dmi)(?!.*min)(?!.*ini)(?!.*nis)(?!.*ist)(?!.*str)(?!.*tra)(?!.*rat)(?!.*ato)(?!.*tor)(?!.*rotartsinimd[A|a]).*$",
+      required: true,
+    };
+  } else {
+    return {
+      regexMessage: "密码不能包含用户名或用户名的逆序。",
+      message: "登录密码不符合规则要求",
+      trigger: "blur",
+      pattern: "^(?!.*(?:root|\\btoor)\\b).*$",
+      regex: "^(?!.*(?:root|\\btoor)\\b).*$",
+      required: true,
+    };
+  }
+});
+
+const pwdRules = [
+  {
+    regexMessage: "8~26个字符。",
+    message: "登录密码不符合规则要求",
+    trigger: "blur",
+    pattern: "^.{8,26}$",
+    regex: "^.{8,26}$",
+    required: true,
+  },
+  {
+    regexMessage:
+      "密码只能包含大写字母、小写字母、数字和特殊宇符(!@$%^-_=+[{}]:,./?~#*)且至少包含四种字符中的三种。",
+    message: "登录密码不符合规则要求",
+    trigger: "blur",
+    pattern:
+      "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[!@$%^\\-_=+[{}\\]:,./?~#*])[a-zA-Z\\d!@$%^\\-_=+[{}\\]:,./?~#*]{8,}$",
+    regex:
+      "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[!@$%^\\-_=+[{}\\]:,./?~#*])[a-zA-Z\\d!@$%^\\-_=+[{}\\]:,./?~#*]{8,}$",
+    required: true,
+  },
+  regexByOs.value,
+];
+
+const _data = computed({
+  get() {
+    return props.modelValue;
+  },
+  set(value) {
+    emit("update:modelValue", value);
+  },
+});
+</script>
+<style lang="scss" scoped>
+.box-content {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  align-items: center;
+  padding: 18px;
+  background-color: #f7f9fc;
+  border-radius: 4px;
+  .el-form-item {
+    margin-bottom: 0;
+    margin-right: 0;
+    padding: 0px 2px 0px 8px;
+    width: 100%;
+    .el-form-item__content .custom-popover {
+      width: 100%;
+    }
+  }
+
+  .delete-icon {
+    cursor: pointer;
+    margin-left: 8px;
+  }
+}
+.add-button {
+  margin: 10px;
+}
+.detail-box {
+  margin-top: 8px;
+  :deep(.el-descriptions__header) {
+    margin-bottom: 0 !important;
+  }
+}
+</style>

--- a/framework/sdk/frontend/commons/components/ce-form/items/tencent/TencentInstanceTypeForm.vue
+++ b/framework/sdk/frontend/commons/components/ce-form/items/tencent/TencentInstanceTypeForm.vue
@@ -1,0 +1,203 @@
+<template>
+  <div style="width: 100%">
+    <template v-if="!confirm">
+      <div class="header">
+        <div class="title">选择实例规格</div>
+        <el-input
+          placeholder="请输入关键字搜索"
+          class="input-with-select"
+          style="--el-color-danger: #c0c4cc"
+          v-model="searchValue"
+          prefix-icon="Search"
+          :validate-event="false"
+        />
+      </div>
+      <el-form
+        ref="ruleFormRef"
+        label-position="left"
+        require-asterisk-position="right"
+        :model="_data"
+      >
+        <div
+          style="
+            width: 100%;
+            display: flex;
+            flex-direction: row;
+            justify-content: space-between;
+          "
+        ></div>
+        <el-form-item prop="instanceType">
+          <el-radio-group v-model="_data.instanceType" style="width: 100%">
+            <el-table
+              ref="singleTableRef"
+              :data="tableData"
+              highlight-current-row
+              style="width: 100%; height: 330px"
+              @current-change="handleCurrentChange"
+            >
+              <el-table-column width="50px">
+                <template #default="scope">
+                  <el-radio :label="scope.row.instanceType">
+                    <template #default>{{}}</template>
+                  </el-radio>
+                </template>
+              </el-table-column>
+              <el-table-column
+                label="规格类型"
+                property="instanceTypeFamilyName"
+              />
+              <el-table-column label="规格名称" property="instanceType" />
+              <el-table-column label="实例规格" property="cpuMemory" />
+            </el-table>
+          </el-radio-group>
+        </el-form-item>
+      </el-form>
+      <div class="msg">
+        <span v-show="props.modelValue">
+          当前选实例规格
+          <span class="active"> {{ props.modelValue?.instanceType }}</span>
+        </span>
+      </div>
+    </template>
+    <template v-else>
+      <el-descriptions>
+        <el-descriptions-item>
+          {{ modelValue.instanceType }}
+        </el-descriptions-item>
+      </el-descriptions>
+    </template>
+  </div>
+</template>
+<script setup lang="ts">
+import type { FormView } from "@commons/components/ce-form/type";
+import { computed, ref, watch } from "vue";
+import _ from "lodash";
+import type { ElTable } from "element-plus";
+
+interface InstanceTypeConfig {
+  instanceTypeFamilyName: string;
+  instanceTypeFamily: string;
+  instanceType: string;
+  cpuMemory: string;
+  cpu: number;
+  memory: number;
+}
+
+const props = defineProps<{
+  modelValue?: InstanceTypeConfig;
+  allData?: any;
+  allFormViewData?: Array<FormView>;
+  field: string;
+  otherParams: any;
+  formItem: FormView;
+  confirm?: boolean;
+}>();
+
+const emit = defineEmits(["update:modelValue", "change"]);
+
+const singleTableRef = ref<InstanceType<typeof ElTable>>();
+const _data = computed({
+  get() {
+    return props.modelValue ? (props.modelValue as InstanceTypeConfig) : {};
+  },
+  set(value) {
+    emit("update:modelValue", value);
+    emit("change");
+  },
+});
+
+const searchValue = ref<string>("");
+
+const tableData = computed(() => {
+  if (props.formItem.optionList) {
+    if (searchValue.value) {
+      return props.formItem.optionList.filter((item: any) =>
+        Object.values(item).some((value) =>
+          String(value).includes(searchValue.value)
+        )
+      );
+    } else {
+      return props.formItem.optionList;
+    }
+  }
+  return [];
+});
+
+/**
+ * 监听表格数据，设置默认值
+ */
+watch(
+  () => tableData.value,
+  () => {
+    if (tableData.value && tableData.value.length > 0) {
+      let defaultItem = _.head(tableData.value) as InstanceTypeConfig;
+      if (props.modelValue) {
+        const row = tableData.value.find(
+          (f: InstanceTypeConfig) =>
+            f.instanceType === props.modelValue?.instanceType
+        );
+        if (row) {
+          defaultItem = row;
+        }
+      }
+      emit("update:modelValue", defaultItem as InstanceTypeConfig);
+    } else {
+      emit("update:modelValue", undefined);
+    }
+    emit("change");
+  }
+);
+
+/**
+ * 列表选中
+ */
+const currentRow = computed<InstanceTypeConfig | undefined>({
+  get() {
+    return _.find(
+      props.formItem?.optionList,
+      (o: InstanceTypeConfig) => o.instanceType === _.get(_data.value,"instanceType")
+    );
+  },
+  set(value) {
+    _data.value = value as InstanceTypeConfig;
+  },
+});
+
+function handleCurrentChange(val: InstanceTypeConfig | undefined) {
+  currentRow.value = val;
+}
+</script>
+<style lang="scss" scoped>
+.header {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 16px;
+  .title {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    color: #1f2329;
+    font-weight: 400;
+    font-size: 14px;
+    line-height: 22px;
+  }
+  .input-with-select {
+    width: 45%;
+  }
+}
+.msg {
+  margin-top: 20px;
+  color: #646a73;
+  height: 22px;
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 22px;
+  .active {
+    color: rgba(51, 112, 255, 1);
+  }
+}
+
+:deep(.el-table th.el-table__cell) {
+  background-color: #f5f6f7;
+}
+</style>

--- a/framework/sdk/frontend/commons/components/ce-form/items/tencent/TencentInstanceTypeForm.vue
+++ b/framework/sdk/frontend/commons/components/ce-form/items/tencent/TencentInstanceTypeForm.vue
@@ -155,7 +155,8 @@ const currentRow = computed<InstanceTypeConfig | undefined>({
   get() {
     return _.find(
       props.formItem?.optionList,
-      (o: InstanceTypeConfig) => o.instanceType === _.get(_data.value,"instanceType")
+      (o: InstanceTypeConfig) =>
+        o.instanceType === _.get(_data.value, "instanceType")
     );
   },
   set(value) {

--- a/framework/sdk/frontend/commons/components/ce-form/items/tencent/TencentServerInfoForm.vue
+++ b/framework/sdk/frontend/commons/components/ce-form/items/tencent/TencentServerInfoForm.vue
@@ -89,7 +89,8 @@ const _loading = ref<boolean>(false);
 
 const nameRules = [
   {
-    message: "2～128个字符",
+    regexMessage: "2～128个字符",
+    message: "云主机名称不符合规则要求",
     trigger: "blur",
     pattern: "^(?!\\s*$).{2,128}$",
     regex: "^(?!\\s*$).{2,128}$",
@@ -98,7 +99,8 @@ const nameRules = [
 ];
 const hostNameRules = [
   {
-    message: "只能包含小写字母、大写字母、数字、点或横线且是合法的FQDN",
+    regexMessage: "只能包含小写字母、大写字母、数字、点或横线且是合法的FQDN",
+    message: "云主机名称不符合规则要求",
     trigger: "blur",
     pattern: "^[A-Za-z]+[A-Za-z0-9\\.\\-]*[A-Za-z0-9]$",
     regex: "^[A-Za-z]+[A-Za-z0-9\\.\\-]*[A-Za-z0-9]$",

--- a/framework/sdk/frontend/commons/components/ce-regex-tooltip/index.vue
+++ b/framework/sdk/frontend/commons/components/ce-regex-tooltip/index.vue
@@ -10,7 +10,7 @@
       :show-arrow="false"
     >
       <template #reference>
-        <div>
+        <div style="width: 100%">
           <slot></slot>
         </div>
       </template>
@@ -41,7 +41,7 @@ const props = withDefaults(
     trigger?: string;
     disabled?: boolean;
     width?: string;
-    modelValue: string;
+    modelValue?: string;
     offset?: number;
     description?: string;
     rules: any;
@@ -53,6 +53,7 @@ const props = withDefaults(
     width: "auto",
     offset: 0,
     rules: [{ regex: /\S/, message: "不能为空" }],
+    modelValue: "",
   }
 );
 const _rules = computed(() => {
@@ -62,14 +63,14 @@ const _rules = computed(() => {
       if (rule?.regex) {
         result.push({
           regex: rule?.regex,
-          message: rule?.message,
+          message: rule?.regexMessage,
           status: isMatch(rule?.regex),
         });
       } else if (rule?.pattern) {
         result.push({
           regex: rule?.pattern,
-          message: rule?.message,
-          status: isMatch(rule?.regex),
+          message: rule?.regexMessage,
+          status: isMatch(rule?.pattern),
         });
       }
     });
@@ -88,6 +89,7 @@ const isMatch = (regex: string) => {
   display: inline-block;
   margin-right: 5px;
   margin-bottom: 5px;
+  width: 100%;
 }
 .tooltip {
   width: 100%;

--- a/services/vm-service/backend/src/main/java/com/fit2cloud/provider/impl/aliyun/entity/request/AliyunConfigUpdateForm.java
+++ b/services/vm-service/backend/src/main/java/com/fit2cloud/provider/impl/aliyun/entity/request/AliyunConfigUpdateForm.java
@@ -17,7 +17,7 @@ public class AliyunConfigUpdateForm {
             valueField = "instanceType",
             method = "getInstanceTypesForConfigUpdate",
             clazz = AliyunCloudProvider.class,
-            propsInfo = "{\"rules\":[{\"message\":\"实例规格不能为空\",\"trigger\":\"change\",\"required\":true}],\"style\":{\"width\":\"100%\",\"height\":\"450px\"},\"showLabel\":false,\"activeMsg\":\"已选实例\",\"title\":\"选择变更实例\",\"tableColumns\":[{\"property\":\"instanceType\",\"label\":\"规格类型\"},{\"property\":\"cpuMemory\",\"label\":\"实例规格\"},{\"property\":\"instanceTypeDesc\",\"label\":\"规格详情\",\"min-width\":\"120px\"}]}"
+            propsInfo = "{\"style\":{\"width\":\"100%\",\"height\":\"450px\"},\"showLabel\":false,\"activeMsg\":\"已选实例\",\"title\":\"选择变更实例\",\"tableColumns\":[{\"property\":\"instanceType\",\"label\":\"规格类型\"},{\"property\":\"cpuMemory\",\"label\":\"实例规格\"},{\"property\":\"instanceTypeDesc\",\"label\":\"规格详情\",\"min-width\":\"120px\"}]}"
     )
     private String newInstanceType;
 }

--- a/services/vm-service/backend/src/main/java/com/fit2cloud/provider/impl/aliyun/entity/request/AliyunVmCreateRequest.java
+++ b/services/vm-service/backend/src/main/java/com/fit2cloud/provider/impl/aliyun/entity/request/AliyunVmCreateRequest.java
@@ -61,8 +61,7 @@ public class AliyunVmCreateRequest extends AliyunBaseRequest implements ICreateS
             defaultValue = "1",
             defaultJsonValue = true,
             attrs = "{\"min\":1,\"max\":10,\"step\":1}",
-            confirmGroup = 1,
-            confirmSpecial = true
+            confirmGroup = 1
     )
     private int count;
 
@@ -76,8 +75,7 @@ public class AliyunVmCreateRequest extends AliyunBaseRequest implements ICreateS
             relationShowValues = "PrePaid",
             relationShows = "instanceChargeType",
             propsInfo = "{\"style\":{\"height\":\"30px\"}}",
-            confirmGroup = 1,
-            confirmSpecial = true
+            confirmGroup = 1
     )
     private String periodNum;
 
@@ -116,7 +114,7 @@ public class AliyunVmCreateRequest extends AliyunBaseRequest implements ICreateS
             textField = "instanceType",
             valueField = "instanceType",
             relationTrigger = "zoneId",
-            propsInfo = "{\"rules\":[{\"message\":\"实例规格不能为空\",\"trigger\":\"change\",\"required\":true}],\"style\":{\"width\":\"100%\",\"height\":\"400px\"},\"showLabel\":false,\"activeMsg\":\"已选实例\",\"title\":\"选择实例规格\",\"tableColumns\":[{\"property\":\"instanceTypeFamilyName\",\"label\":\"规格类型\",\"min-width\":\"120px\"},{\"property\":\"instanceType\",\"label\":\"规格名称\"},{\"property\":\"cpuMemory\",\"label\":\"实例规格\"}]}",
+            propsInfo = "{\"style\":{\"width\":\"100%\",\"height\":\"400px\"},\"showLabel\":false,\"activeMsg\":\"已选实例\",\"title\":\"选择实例规格\",\"tableColumns\":[{\"property\":\"instanceTypeFamilyName\",\"label\":\"规格类型\",\"min-width\":\"120px\"},{\"property\":\"instanceType\",\"label\":\"规格名称\"},{\"property\":\"cpuMemory\",\"label\":\"实例规格\"}]}",
             step = 1,
             group = 3,
             confirmGroup = 1
@@ -264,13 +262,12 @@ public class AliyunVmCreateRequest extends AliyunBaseRequest implements ICreateS
             description = "密码须同时符合以下规则",
             relationShows = "loginType",
             relationShowValues = "password",
-            regexList = "[" +
-                    "{\"regex\":\"^(?!/)(?![\\\\da-z]+$)(?![\\\\dA-Z]+$)(?![\\\\d\\\\(\\\\)`~!@#\\\\$%\\\\^&\\\\*\\\\-\\\\+=_\\\\|\\\\{\\\\}\\\\[\\\\]:;'<>,\\\\.\\\\?/]+$)(?![a-zA-Z]+$)(?![a-z\\\\(\\\\)`~!@#\\\\$%\\\\^&\\\\*\\\\-\\\\+=_\\\\|\\\\{\\\\}\\\\[\\\\]:;'<>,\\\\.\\\\?/]+$)(?![A-Z\\\\(\\\\)`~!@#\\\\$%\\\\^&\\\\*\\\\-\\\\+=_\\\\|\\\\{\\\\}\\\\[\\\\]:;'<>,\\\\.\\\\?/]+$)[\\\\da-zA-z\\\\(\\\\)`~!@#\\\\$%\\\\^&\\\\*\\\\-\\\\+=_\\\\|\\\\{\\\\}\\\\[\\\\]:;'<>,\\\\.\\\\?/]{8,30}$\"" +
-                    ",\"message\":\"在 8 ～ 30 位字符数以内，不能以\\\" / \\\"开头，至少包含其中三项(小写字母 a ~ z、大写字母 A ～ Z、数字 0 ～ 9、()`~!@#$%^&*-+=_|{}[]:;'<>,.?/)\"}]",
-            propsInfo = "{\"style\":{\"width\":\"100%\"}}",
+            propsInfo = "{\"rules\":[{\"message\":\"登录密码不符合规则\",\"trigger\":\"blur\",\"required\":true,\"pattern\":\"^(?!/)(?![\\\\da-z]+$)(?![\\\\dA-Z]+$)(?![\\\\d\\\\(\\\\)`~!@#\\\\$%\\\\^&\\\\*\\\\-\\\\+=_\\\\|\\\\{\\\\}\\\\[\\\\]:;'<>,\\\\.\\\\?/]+$)(?![a-zA-Z]+$)(?![a-z\\\\(\\\\)`~!@#\\\\$%\\\\^&\\\\*\\\\-\\\\+=_\\\\|\\\\{\\\\}\\\\[\\\\]:;'<>,\\\\.\\\\?/]+$)(?![A-Z\\\\(\\\\)`~!@#\\\\$%\\\\^&\\\\*\\\\-\\\\+=_\\\\|\\\\{\\\\}\\\\[\\\\]:;'<>,\\\\.\\\\?/]+$)[\\\\da-zA-z\\\\(\\\\)`~!@#\\\\$%\\\\^&\\\\*\\\\-\\\\+=_\\\\|\\\\{\\\\}\\\\[\\\\]:;'<>,\\\\.\\\\?/]{8,30}$\",\"regexMessage\":\"在 8 ～ 30 位字符数以内，不能以\\\" / \\\"开头，至少包含其中三项(小写字母 a ~ z、大写字母 A ～ Z、数字 0 ～ 9、()`~!@#$%^&*-+=_|{}[]:;'<>,.?/)\"}],\"style\":{\"width\":\"100%\"}}",
             step = 3,
             group = 8,
-            encrypted = true
+            confirmGroup = 3,
+            encrypted = true,
+            confirmSpecial = true
     )
     private String password;
 

--- a/services/vm-service/backend/src/main/java/com/fit2cloud/provider/impl/huawei/entity/request/HuaweiConfigUpdateForm.java
+++ b/services/vm-service/backend/src/main/java/com/fit2cloud/provider/impl/huawei/entity/request/HuaweiConfigUpdateForm.java
@@ -16,7 +16,7 @@ public class HuaweiConfigUpdateForm {
             textField = "instanceTypeDesc",
             valueField = "specName",
             method = "getInstanceTypesForConfigUpdate",
-            propsInfo = "{\"rules\":[{\"message\":\"实例规格不能为空\",\"trigger\":\"change\",\"required\":true}],\"style\":{\"width\":\"100%\",\"height\":\"450px\"},\"showLabel\":false,\"activeMsg\":\"已选实例\",\"title\":\"选择变更实例\",\"tableColumns\":[{\"property\":\"specName\",\"label\":\"规格类型\"},{\"property\":\"instanceSpec\",\"label\":\"实例规格\"},{\"property\":\"instanceTypeDesc\",\"label\":\"规格详情\",\"min-width\":\"120px\"}]}",
+            propsInfo = "{\"style\":{\"width\":\"100%\",\"height\":\"450px\"},\"showLabel\":false,\"activeMsg\":\"已选实例\",\"title\":\"选择变更实例\",\"tableColumns\":[{\"property\":\"specName\",\"label\":\"规格类型\"},{\"property\":\"instanceSpec\",\"label\":\"实例规格\"},{\"property\":\"instanceTypeDesc\",\"label\":\"规格详情\",\"min-width\":\"120px\"}]}",
             clazz = HuaweiCloudProvider.class)
     private String newInstanceType;
 }

--- a/services/vm-service/backend/src/main/java/com/fit2cloud/provider/impl/huawei/entity/request/HuaweiVmCreateRequest.java
+++ b/services/vm-service/backend/src/main/java/com/fit2cloud/provider/impl/huawei/entity/request/HuaweiVmCreateRequest.java
@@ -112,7 +112,7 @@ public class HuaweiVmCreateRequest extends HuaweiBaseRequest implements ICreateS
             textField = "instanceSpec",
             valueField = "specName",
             relationTrigger = {"availabilityZone", "billingMode"},
-            propsInfo = "{\"rules\":[{\"message\":\"实例规格不能为空\",\"trigger\":\"change\",\"required\":true}],\"style\":{\"width\":\"100%\",\"height\":\"400px\"},\"showLabel\":false,\"activeMsg\":\"已选实例\",\"title\":\"选择实例规格\",\"tableColumns\":[{\"property\":\"specType\",\"label\":\"规格类型\",\"min-width\":\"120px\"},{\"property\":\"specName\",\"label\":\"规格名称\"},{\"property\":\"instanceSpec\",\"label\":\"实例规格\"}]}",
+            propsInfo = "{\"style\":{\"width\":\"100%\",\"height\":\"400px\"},\"showLabel\":false,\"activeMsg\":\"已选实例\",\"title\":\"选择实例规格\",\"tableColumns\":[{\"property\":\"specType\",\"label\":\"规格类型\",\"min-width\":\"120px\"},{\"property\":\"specName\",\"label\":\"规格名称\"},{\"property\":\"instanceSpec\",\"label\":\"实例规格\"}]}",
             step = 1,
             group = 3,
             confirmGroup = 1
@@ -170,8 +170,8 @@ public class HuaweiVmCreateRequest extends HuaweiBaseRequest implements ICreateS
             method = "listSubnet",
             textField = "name",
             valueField = "uuid",
-            relationTrigger = {"regionId","availabilityZone"},
-            propsInfo = "{\"rules\":[{\"message\":\"网络不能为空\",\"trigger\":\"change\",\"required\":true}],\"style\":{\"width\":\"100%\",\"height\":\"400px\"},\"showLabel\":false,\"activeMsg\":\"已选网络\",\"title\":\"选择网络\",\"tableColumns\":[{\"property\":\"name\",\"label\":\"子网名称\",\"min-width\":\"120px\"},{\"property\":\"vpcName\",\"label\":\"所属VPC\"},{\"property\":\"cidr\",\"label\":\"IPV4网段\"}]}",
+            relationTrigger = {"regionId", "availabilityZone"},
+            propsInfo = "{\"style\":{\"width\":\"100%\",\"height\":\"400px\"},\"showLabel\":false,\"activeMsg\":\"已选网络\",\"title\":\"选择网络\",\"tableColumns\":[{\"property\":\"name\",\"label\":\"子网名称\",\"min-width\":\"120px\"},{\"property\":\"vpcName\",\"label\":\"所属VPC\"},{\"property\":\"cidr\",\"label\":\"IPV4网段\"}]}",
             step = 2,
             group = 6,
             confirmGroup = 2
@@ -282,18 +282,16 @@ public class HuaweiVmCreateRequest extends HuaweiBaseRequest implements ICreateS
     )
     private String loginName;
 
-    @Form(inputType = InputType.RegexInput,
+    @Form(inputType = InputType.HuaweiPasswordInfoForm,
             label = "登录密码",
-            description = "密码须同时符合以下规则",
             relationShows = "loginMethod",
             relationShowValues = "pwd",
-            regexList = "[" +
-                    "{\"regex\":\"^((?=.*\\\\d)(?=.*[a-z])(?=.*[A-Z])(?!.*root)(?!.*toor)(?!.*[A|a]dministrator)(?!.*rotartsinimd[A|a]).{8,25})$\"" +
-                    ",\"message\":\"必须包含大小写字母和数字的组合，可以使用特殊字符，不能包含用户名或逆向用户名，长度在8-26之间\"}]",
-            propsInfo = "{\"style\":{\"width\":\"100%\"}}",
+            propsInfo = "{\"rules\":[{\"message\":\"登录密码不符合规则\",\"trigger\":\"blur\",\"required\":true}]}",
             step = 3,
             group = 8,
-            encrypted = true
+            confirmGroup = 3,
+            encrypted = true,
+            confirmSpecial = true
     )
     private String pwd;
 
@@ -329,7 +327,7 @@ public class HuaweiVmCreateRequest extends HuaweiBaseRequest implements ICreateS
             label = "配置费用",
             clazz = HuaweiCloudProvider.class,
             method = "calculateConfigPrice",
-            relationTrigger = {"billingMode", "periodNum", "availabilityZone", "instanceType", "disks", "count","trafficBandwidthSize", "bandwidthSize","chargeMode","usePublicIp"},
+            relationTrigger = {"billingMode", "periodNum", "availabilityZone", "instanceType", "disks", "count", "trafficBandwidthSize", "bandwidthSize", "chargeMode", "usePublicIp"},
             attrs = "{\"style\":\"color: red; font-size: large\"}",
             confirmGroup = 1,
             required = false,

--- a/services/vm-service/backend/src/main/java/com/fit2cloud/provider/impl/tencent/api/TencentSyncCloudApi.java
+++ b/services/vm-service/backend/src/main/java/com/fit2cloud/provider/impl/tencent/api/TencentSyncCloudApi.java
@@ -188,7 +188,7 @@ public class TencentSyncCloudApi {
                 .setId(request.getId())
                 .setName(request.getServerInfos().get(index).getName())
                 .setIpArray(new ArrayList<>())
-                .setInstanceType(StringUtils.isEmpty(request.getInstanceType()) ? "" : request.getInstanceType());
+                .setInstanceType(request.getInstanceTypeDTO() != null ? StringUtils.isEmpty(request.getInstanceTypeDTO().getInstanceType()) ? "" : request.getInstanceTypeDTO().getInstanceType() : "");
 
         return virtualMachine;
     }

--- a/services/vm-service/backend/src/main/java/com/fit2cloud/provider/impl/tencent/entity/request/TencentConfigUpdateForm.java
+++ b/services/vm-service/backend/src/main/java/com/fit2cloud/provider/impl/tencent/entity/request/TencentConfigUpdateForm.java
@@ -16,7 +16,7 @@ public class TencentConfigUpdateForm {
             textField = "instanceTypeDesc",
             valueField = "instanceType",
             method = "getInstanceTypesForConfigUpdate",
-            propsInfo = "{\"rules\":[{\"message\":\"实例规格不能为空\",\"trigger\":\"change\",\"required\":true}],\"style\":{\"width\":\"100%\",\"height\":\"450px\"},\"showLabel\":false,\"activeMsg\":\"已选实例\",\"title\":\"选择变更实例\",\"tableColumns\":[{\"property\":\"instanceType\",\"label\":\"规格类型\"},{\"property\":\"cpuMemory\",\"label\":\"实例规格\"},{\"property\":\"instanceTypeDesc\",\"label\":\"规格详情\",\"min-width\":\"120px\"}]}",
+            propsInfo = "{\"style\":{\"width\":\"100%\",\"height\":\"450px\"},\"showLabel\":false,\"activeMsg\":\"已选实例\",\"title\":\"选择变更实例\",\"tableColumns\":[{\"property\":\"instanceType\",\"label\":\"规格类型\"},{\"property\":\"cpuMemory\",\"label\":\"实例规格\"},{\"property\":\"instanceTypeDesc\",\"label\":\"规格详情\",\"min-width\":\"120px\"}]}",
             clazz = TencentCloudProvider.class)
     private String newInstanceType;
 }

--- a/services/vm-service/backend/src/main/java/com/fit2cloud/provider/impl/tencent/entity/request/TencentGetImageRequest.java
+++ b/services/vm-service/backend/src/main/java/com/fit2cloud/provider/impl/tencent/entity/request/TencentGetImageRequest.java
@@ -41,8 +41,8 @@ public class TencentGetImageRequest extends TencentVmCreateRequest {
         if (CollectionUtils.isNotEmpty(filters)) {
             describeImagesRequest.setFilters(filters.toArray(new Filter[]{}));
         }
-        if (StringUtils.isNotEmpty(this.getInstanceType())) {
-            describeImagesRequest.setInstanceType(this.getInstanceType());
+        if (this.getInstanceTypeDTO() != null && StringUtils.isNotEmpty(this.getInstanceTypeDTO().getInstanceType())) {
+            describeImagesRequest.setInstanceType(this.getInstanceTypeDTO().getInstanceType());
         }
         return describeImagesRequest;
     }

--- a/services/vm-service/backend/src/main/java/com/fit2cloud/provider/impl/tencent/entity/request/TencentVmCreateRequest.java
+++ b/services/vm-service/backend/src/main/java/com/fit2cloud/provider/impl/tencent/entity/request/TencentVmCreateRequest.java
@@ -9,6 +9,7 @@ import com.fit2cloud.provider.ICreateServerRequest;
 import com.fit2cloud.provider.impl.tencent.TencentCloudProvider;
 import com.fit2cloud.provider.impl.tencent.constants.TencentBandwidthType;
 import com.fit2cloud.provider.impl.tencent.constants.TencentChargeType;
+import com.fit2cloud.provider.impl.tencent.entity.TencentInstanceType;
 import com.tencentcloudapi.cvm.v20170312.models.*;
 import lombok.Data;
 import lombok.experimental.Accessors;
@@ -108,19 +109,18 @@ public class TencentVmCreateRequest extends TencentBaseRequest implements ICreat
     )
     private String zoneId;
 
-    @Form(inputType = InputType.TableRadio,
+    @Form(inputType = InputType.TencentInstanceTypeForm,
             label = "实例规格",
             clazz = TencentCloudProvider.class,
             method = "getInstanceTypes",
-            textField = "instanceType",
-            valueField = "instanceType",
             relationTrigger = {"instanceChargeType", "zoneId"},
-            propsInfo = "{\"rules\":[{\"message\":\"实例规格不能为空\",\"trigger\":\"change\",\"required\":true}],\"style\":{\"width\":\"100%\",\"height\":\"400px\"},\"showLabel\":false,\"activeMsg\":\"已选实例\",\"title\":\"选择实例规格\",\"tableColumns\":[{\"property\":\"instanceTypeFamilyName\",\"label\":\"规格类型\",\"min-width\":\"120px\"},{\"property\":\"instanceType\",\"label\":\"规格名称\"},{\"property\":\"cpuMemory\",\"label\":\"实例规格\"}]}",
+            propsInfo = "{\"showLabel\":false}",
             step = 1,
             group = 3,
-            confirmGroup = 1
+            confirmGroup = 1,
+            confirmSpecial = true
     )
-    private String instanceType;
+    TencentInstanceType instanceTypeDTO;
 
     @Form(inputType = InputType.SingleSelect,
             label = "操作系统",
@@ -142,7 +142,7 @@ public class TencentVmCreateRequest extends TencentBaseRequest implements ICreat
             method = "getImages",
             textField = "name",
             valueField = "id",
-            relationTrigger = {"instanceType", "os"},
+            relationTrigger = {"instanceTypeDTO", "os"},
             propsInfo = "{\"style\":{\"width\":\"100%\"}}",
             step = 1,
             group = 4,
@@ -158,7 +158,7 @@ public class TencentVmCreateRequest extends TencentBaseRequest implements ICreat
             method = "getDiskTypesForCreateVm",
             defaultValue = "[]",
             defaultJsonValue = true,
-            relationTrigger = {"instanceChargeType", "zoneId", "instanceType"},
+            relationTrigger = {"instanceChargeType", "zoneId", "instanceTypeDTO"},
             step = 1,
             group = 5,
             confirmGroup = 1,
@@ -173,7 +173,7 @@ public class TencentVmCreateRequest extends TencentBaseRequest implements ICreat
             textField = "networkName",
             valueField = "networkId",
             relationTrigger = "zoneId",
-            propsInfo = "{\"rules\":[{\"message\":\"网络不能为空\",\"trigger\":\"change\",\"required\":true}],\"style\":{\"width\":\"100%\",\"height\":\"400px\"},\"showLabel\":false,\"activeMsg\":\"已选网络\",\"title\":\"选择网络\",\"tableColumns\":[{\"property\":\"networkName\",\"label\":\"子网\",\"min-width\":\"120px\"},{\"property\":\"vpcName\",\"label\":\"所属VPC\"},{\"property\":\"ipSegment\",\"label\":\"IPV4网段\"}]}",
+            propsInfo = "{\"style\":{\"width\":\"100%\",\"height\":\"400px\"},\"showLabel\":false,\"activeMsg\":\"已选网络\",\"title\":\"选择网络\",\"tableColumns\":[{\"property\":\"networkName\",\"label\":\"子网\",\"min-width\":\"120px\"},{\"property\":\"vpcName\",\"label\":\"所属VPC\"},{\"property\":\"ipSegment\",\"label\":\"IPV4网段\"}]}",
             step = 2,
             group = 6,
             confirmGroup = 2
@@ -264,11 +264,12 @@ public class TencentVmCreateRequest extends TencentBaseRequest implements ICreat
             description = "密码须同时符合以下规则",
             relationShows = "loginType",
             relationShowValues = "password",
-            regexList = "[{\"regex\":\"^(?!/)(?![\\\\da-z]+$)(?![\\\\dA-Z]+$)(?![\\\\d\\\\(\\\\)`~!@#\\\\$%\\\\^&\\\\*\\\\-\\\\+=_\\\\|\\\\{\\\\}\\\\[\\\\]:;'<>,\\\\.\\\\?/]+$)(?![a-zA-Z]+$)(?![a-z\\\\(\\\\)`~!@#\\\\$%\\\\^&\\\\*\\\\-\\\\+=_\\\\|\\\\{\\\\}\\\\[\\\\]:;'<>,\\\\.\\\\?/]+$)(?![A-Z\\\\(\\\\)`~!@#\\\\$%\\\\^&\\\\*\\\\-\\\\+=_\\\\|\\\\{\\\\}\\\\[\\\\]:;'<>,\\\\.\\\\?/]+$)[\\\\da-zA-z\\\\(\\\\)`~!@#\\\\$%\\\\^&\\\\*\\\\-\\\\+=_\\\\|\\\\{\\\\}\\\\[\\\\]:;'<>,\\\\.\\\\?/]{12,30}$\",\"message\":\"在 12 ～ 30 位字符数以内，不能以' / '开头，至少包含其中三项(小写字母 a ~ z、大写字母 A ～ Z、数字 0 ～ 9、()`~!@#$%^&*-+=_|{}[]:;'<>,.?/)\"}]",
-            propsInfo = "{\"style\":{\"width\":\"100%\"}}",
-            encrypted = true,
+            propsInfo = "{\"rules\":[{\"message\":\"登录密码不符合规则\",\"trigger\":\"blur\",\"required\":true,\"pattern\":\"^(?!/)(?![\\\\da-z]+$)(?![\\\\dA-Z]+$)(?![\\\\d\\\\(\\\\)`~!@#\\\\$%\\\\^&\\\\*\\\\-\\\\+=_\\\\|\\\\{\\\\}\\\\[\\\\]:;'<>,\\\\.\\\\?/]+$)(?![a-zA-Z]+$)(?![a-z\\\\(\\\\)`~!@#\\\\$%\\\\^&\\\\*\\\\-\\\\+=_\\\\|\\\\{\\\\}\\\\[\\\\]:;'<>,\\\\.\\\\?/]+$)(?![A-Z\\\\(\\\\)`~!@#\\\\$%\\\\^&\\\\*\\\\-\\\\+=_\\\\|\\\\{\\\\}\\\\[\\\\]:;'<>,\\\\.\\\\?/]+$)[\\\\da-zA-z\\\\(\\\\)`~!@#\\\\$%\\\\^&\\\\*\\\\-\\\\+=_\\\\|\\\\{\\\\}\\\\[\\\\]:;'<>,\\\\.\\\\?/]{12,30}$\",\"regexMessage\":\"在 12 ～ 30 位字符数以内，不能以' / '开头，至少包含其中三项(小写字母 a ~ z、大写字母 A ～ Z、数字 0 ～ 9、()`~!@#$%^&*-+=_|{}[]:;'<>,.?/)\"}],\"style\":{\"width\":\"100%\"}}",
             step = 3,
-            group = 8
+            group = 8,
+            confirmGroup = 3,
+            encrypted = true,
+            confirmSpecial = true
     )
     private String password;
 
@@ -289,7 +290,7 @@ public class TencentVmCreateRequest extends TencentBaseRequest implements ICreat
             attrs = "{\"style\":\"color: red; font-size: large\"}",
             confirmGroup = 1,
             footerLocation = 1,
-            relationTrigger = {"hasPublicIp", "bandwidth", "bandwidthChargeType", "count", "instanceChargeType", "periodNum", "instanceType", "osVersion", "disks"},
+            relationTrigger = {"hasPublicIp", "bandwidth", "bandwidthChargeType", "count", "instanceChargeType", "periodNum", "instanceTypeDTO", "osVersion", "disks"},
             confirmSpecial = true,
             required = false
     )
@@ -332,8 +333,8 @@ public class TencentVmCreateRequest extends TencentBaseRequest implements ICreat
         placement.setZone(this.zoneId);
         runInstancesRequest.setPlacement(placement);
         runInstancesRequest.setImageId(this.osVersion);
-        if (StringUtils.isNotEmpty(this.getInstanceType())) {
-            runInstancesRequest.setInstanceType(this.getInstanceType());
+        if (this.instanceTypeDTO != null && StringUtils.isNotEmpty(this.instanceTypeDTO.getInstanceType())) {
+            runInstancesRequest.setInstanceType(this.instanceTypeDTO.getInstanceType());
         }
 
         // 设置机器收费类型:按需或者包周期
@@ -396,8 +397,8 @@ public class TencentVmCreateRequest extends TencentBaseRequest implements ICreat
         placement.setZone(this.zoneId);
         req.setPlacement(placement);
         req.setImageId(this.osVersion);
-        if (StringUtils.isNotEmpty(this.getInstanceType())) {
-            req.setInstanceType(this.getInstanceType());
+        if (this.instanceTypeDTO != null && StringUtils.isNotEmpty(this.instanceTypeDTO.getInstanceType())) {
+            req.setInstanceType(this.instanceTypeDTO.getInstanceType());
         }
         req.setInstanceChargeType(this.instanceChargeType);
         if (TencentChargeType.PREPAID.getId().equalsIgnoreCase(this.instanceChargeType)) {

--- a/services/vm-service/frontend/src/views/vm_cloud_server/create/CeFormItem.vue
+++ b/services/vm-service/frontend/src/views/vm_cloud_server/create/CeFormItem.vue
@@ -164,7 +164,7 @@ function checkShow(currentItem: any): any {
 }
 function rules(currentItem: any) {
   const rules = [];
-  if (currentItem.required) {
+  if (currentItem.required && !currentItem.propsInfo?.rules) {
     rules.push({
       message: currentItem.label + "不能为空",
       trigger: "change",
@@ -261,11 +261,12 @@ function initForms(): void {
  * @param formItem
  */
 const change = (formItem: FormView) => {
-  //console.log(formItem.field);
+  console.log(formItem.field);
   _.forEach(props.allFormViewData, (item) => {
     if (_.includes(item.relationTrigger, formItem.field)) {
       //console.log(formItem.field, "in", item.field);
       //设置空值
+
       _.set(_data.value, item.field, undefined);
       if (item.method === "calculateConfigPrice") {
         emit("optionListRefresh", item.field);

--- a/services/vm-service/frontend/src/views/vm_cloud_server/create/CreateConfirmStep.vue
+++ b/services/vm-service/frontend/src/views/vm_cloud_server/create/CreateConfirmStep.vue
@@ -41,12 +41,7 @@
             </template>
           </template>
           <!--暂时支持阿里云新的UI-->
-          <template
-            v-if="
-              props.cloudAccount?.platform !== 'fit2cloud_vsphere_platform' &&
-              props.cloudAccount?.platform !== 'fit2cloud_openstack_platform'
-            "
-          >
+          <template v-if="false">
             <detail-page
               :content="getGroupFormDetail(group)"
               :item-width="'33.33%'"
@@ -77,7 +72,7 @@
               <template v-for="form in group.forms" :key="form.index">
                 <template v-if="form.label && checkShow(form)">
                   <el-descriptions-item
-                    :label="form.label"
+                    :label="getLabel(form)"
                     :span="form.confirmItemSpan"
                     :width="_width * form.confirmItemSpan + '%'"
                     :data-var="(form._display = getDisplayValue(form))"
@@ -206,10 +201,22 @@ function checkShow(currentItem: any) {
 }
 
 /**
+ * 加密字段特殊处理，可以理解为加密字段不显示，但是占用位置
+ * 加密字段不显示label,但是需要它占用一个位置，因为1个groups中有3个form,有一个form不显示的话，只显示两个form页面上就不对称
+ * @param form
+ */
+function getLabel(form: FormView) {
+  return form.encrypted ? "" : form.label;
+}
+/**
  * 处理列表中取值展示
  * @param form
  */
 function getDisplayValue(form: FormView) {
+  //加密字段不显示内容
+  if (form.encrypted) {
+    return "";
+  }
   const value = _.get(props.allData, form.field);
   let result: any = _.clone(value);
   if (!form.confirmSpecial) {


### PR DESCRIPTION
fix(vm-service,sdk): 创建云主机BUG修复  1.创建公有云云主机基础配置界面，数据盘可以输入小于20的值问题。 2.创建公有云云主机，系统盘大小无法调整，磁盘的可随实例删除选项丢失问题。 3.【华为云】-创建云主机网络配置界面，搜索框样式不一致，公网IP流量/带宽费用不更新，配置费用不跟随购买数量变动问题。 4.【华为云】-创建云主机，切换区域后安全组选项依然记录了前一次的选择问题 5.【腾讯云】-创建云主机，数据盘类型与云平台类型不匹配，默认选择了一个不支持的类型问题 6.【腾讯云】-创建云主机IP带宽值限制错误，密码、主机名、hostname提示语没有 7.创建阿里云主机，密码规则提示语表述不当,提示描述改为：登录密码必须同时符合以下规则 