### PR TITLE
fix: 【管理中心】云账号详情页面编辑云账号名称可以重名

### DIFF
--- a/framework/management-center/backend/src/main/java/com/fit2cloud/controller/CloudAccountController.java
+++ b/framework/management-center/backend/src/main/java/com/fit2cloud/controller/CloudAccountController.java
@@ -25,13 +25,13 @@ import com.fit2cloud.service.ICloudAccountService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.annotation.Resource;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
-import jakarta.annotation.Resource;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -234,7 +234,8 @@ public class CloudAccountController {
             resourceId = "#updateAccountNameRequest.id",
             content = "'编辑云账号名称为['+#updateAccountNameRequest.name+']'",
             param = "#updateAccountNameRequest")
-    public ResultHolder<Boolean> updateAccountName(@RequestBody UpdateAccountNameRequest updateAccountNameRequest) {
+    @Emit(value = "UPDATE::CLOUD_ACCOUNT", el = "#updateAccountNameRequest.id")
+    public ResultHolder<Boolean> updateAccountName(@Validated(ValidationGroup.UPDATE.class) @RequestBody UpdateAccountNameRequest updateAccountNameRequest) {
         return ResultHolder.success(cloudAccountService.updateAccountName(updateAccountNameRequest));
     }
 

--- a/framework/management-center/backend/src/main/java/com/fit2cloud/controller/request/cloud_account/UpdateAccountNameRequest.java
+++ b/framework/management-center/backend/src/main/java/com/fit2cloud/controller/request/cloud_account/UpdateAccountNameRequest.java
@@ -1,7 +1,10 @@
 package com.fit2cloud.controller.request.cloud_account;
 
+import com.fit2cloud.common.validator.annnotaion.CustomQueryWrapperValidated;
 import com.fit2cloud.common.validator.annnotaion.CustomValidated;
+import com.fit2cloud.common.validator.group.ValidationGroup;
 import com.fit2cloud.common.validator.handler.ExistHandler;
+import com.fit2cloud.common.validator.handler.ExistQueryWrapperValidatedHandler;
 import com.fit2cloud.dao.mapper.CloudAccountMapper;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
@@ -9,6 +12,11 @@ import lombok.Data;
 import jakarta.validation.constraints.NotNull;
 
 @Data
+@CustomQueryWrapperValidated(groups = ValidationGroup.UPDATE.class,
+        handler = ExistQueryWrapperValidatedHandler.class,
+        el = "#getQueryWrapper().ne(\"id\",#this.id).eq(\"name\",#this.name)",
+        message = "云账号名称不能重复", exist = true,
+        mapper = CloudAccountMapper.class)
 public class UpdateAccountNameRequest {
     @Schema(title = "云账号id", description = "云账号id")
     @NotNull(message = "云账号id不能为null")


### PR DESCRIPTION
fix: 【管理中心】云账号详情页面编辑云账号名称可以重名 