### PR TITLE
fix: 【管理中心】重复添加系统管理员角色，用户角色重复展示多条。删除多余角色后，用户该角色会被全部清空

### DIFF
--- a/framework/management-center/backend/src/main/java/com/fit2cloud/service/impl/UserServiceImpl.java
+++ b/framework/management-center/backend/src/main/java/com/fit2cloud/service/impl/UserServiceImpl.java
@@ -37,6 +37,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import jakarta.annotation.Resource;
+
 import java.text.SimpleDateFormat;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -501,7 +502,8 @@ public class UserServiceImpl extends ServiceImpl<UserMapper, User> implements IU
         userRoleService.saveOrUpdate(userRole, new LambdaQueryWrapper<UserRole>()
                 .eq(UserRole::getRoleId, userRole.getRoleId())
                 .eq(UserRole::getUserId, userRole.getUserId())
-                .eq(UserRole::getSource, userRole.getSource())
+                .eq(sourceId != null, UserRole::getSource, userRole.getSource())
+                .isNull(sourceId == null, UserRole::getSource)
         );
     }
 

--- a/framework/sdk/backend/src/main/java/com/fit2cloud/base/service/impl/BaseUserRoleServiceImpl.java
+++ b/framework/sdk/backend/src/main/java/com/fit2cloud/base/service/impl/BaseUserRoleServiceImpl.java
@@ -160,6 +160,7 @@ public class BaseUserRoleServiceImpl extends ServiceImpl<BaseUserRoleMapper, Use
                 .eq(UserRole::getUserId, userId)
                 .eq(UserRole::getRoleId, roleId)
                 .eq(StringUtils.isNotEmpty(sourceId), UserRole::getSource, sourceId)
+                .last("limit 1")
         );
     }
 


### PR DESCRIPTION
fix: 【管理中心】重复添加系统管理员角色，用户角色重复展示多条。删除多余角色后，用户该角色会被全部清空  修改后： 1. 添加系统管理员与继承系统管理员的角色增加去重 2. 删除用户角色增加只删除一条的限制 